### PR TITLE
Fix Mixin panic on nil Paths and add test for it. Issue #12

### DIFF
--- a/fixtures/no-paths.yml
+++ b/fixtures/no-paths.yml
@@ -1,0 +1,38 @@
+---
+swagger: '2.0'
+info:
+  title: no paths API
+  version: 4.1.7
+schemes:
+  - http
+basePath: /wooble
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+definitions:
+  common:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        format: string
+        minLength: 1
+parameters:
+  common:
+    name: common
+    in: query
+    type: string
+
+responses:
+  401:
+    description: bar unauthorized
+    schema:
+      $ref: "#/definitions/error"
+  404:
+    description: bar resource not found
+    schema:
+      $ref: "#/definitions/error"

--- a/mixin_test.go
+++ b/mixin_test.go
@@ -3,9 +3,10 @@ package analysis
 import "testing"
 
 const (
-	widgetFile = "fixtures/widget-crud.yml"
-	fooFile    = "fixtures/foo-crud.yml"
-	barFile    = "fixtures/bar-crud.yml"
+	widgetFile  = "fixtures/widget-crud.yml"
+	fooFile     = "fixtures/foo-crud.yml"
+	barFile     = "fixtures/bar-crud.yml"
+	noPathsFile = "fixtures/no-paths.yml"
 )
 
 func TestMixin(t *testing.T) {
@@ -22,10 +23,14 @@ func TestMixin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not load '%v': %v\n", barFile, err)
 	}
+	mixin3, err := loadSpec(noPathsFile)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", noPathsFile, err)
+	}
 
-	collisions := Mixin(primary, mixin1, mixin2)
-	if len(collisions) != 12 {
-		t.Errorf("TestMixin: Expected 10 collisions, got %v\n", len(collisions))
+	collisions := Mixin(primary, mixin1, mixin2, mixin3)
+	if len(collisions) != 16 {
+		t.Errorf("TestMixin: Expected 16 collisions, got %v\n%v", len(collisions), collisions)
 	}
 
 	if len(primary.Paths.Paths) != 7 {


### PR DESCRIPTION
Bugfix/Issue #12: Specs with empty paths field create nil .Paths which panics Mixin() 

     paths: 

PR for go-swagger/go-swagger #1005 needs this in order avoid an extra vendoring bump for analysis pkg.