### PR TITLE
fixed some NPEs resulting from un-initialized data structs

### DIFF
--- a/fixtures/empty-paths.json
+++ b/fixtures/empty-paths.json
@@ -1,0 +1,8 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "empty-paths",
+        "version": "79.2.1"
+    },
+    "paths": {}
+}

--- a/mixin.go
+++ b/mixin.go
@@ -32,6 +32,19 @@ func Mixin(primary *spec.Swagger, mixins ...*spec.Swagger) []string {
 	if primary.Paths == nil {
 		primary.Paths = &spec.Paths{Paths: make(map[string]spec.PathItem)}
 	}
+	if primary.Paths.Paths == nil {
+		primary.Paths.Paths = make(map[string]spec.PathItem)
+	}
+	if primary.Definitions == nil {
+		primary.Definitions = make(spec.Definitions)
+	}
+	if primary.Parameters == nil {
+		primary.Parameters = make(map[string]spec.Parameter)
+	}
+	if primary.Responses == nil {
+		primary.Responses = make(map[string]spec.Response)
+	}
+
 	for i, m := range mixins {
 		for k, v := range m.Definitions {
 			// assume name collisions represent IDENTICAL type. careful.

--- a/mixin_test.go
+++ b/mixin_test.go
@@ -3,10 +3,11 @@ package analysis
 import "testing"
 
 const (
-	widgetFile  = "fixtures/widget-crud.yml"
-	fooFile     = "fixtures/foo-crud.yml"
-	barFile     = "fixtures/bar-crud.yml"
-	noPathsFile = "fixtures/no-paths.yml"
+	widgetFile     = "fixtures/widget-crud.yml"
+	fooFile        = "fixtures/foo-crud.yml"
+	barFile        = "fixtures/bar-crud.yml"
+	noPathsFile    = "fixtures/no-paths.yml"
+	emptyPathsFile = "fixtures/empty-paths.json"
 )
 
 func TestMixin(t *testing.T) {
@@ -47,6 +48,17 @@ func TestMixin(t *testing.T) {
 
 	if len(primary.Responses) != 2 {
 		t.Errorf("TestMixin: Expected 2 top level responses in merged, got %v\n", len(primary.Responses))
+	}
+
+	// test that adding paths to a primary with no paths works (was NPE)
+	emptyPaths, err := loadSpec(emptyPathsFile)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", emptyPathsFile, err)
+	}
+
+	collisions = Mixin(emptyPaths, primary)
+	if len(collisions) != 0 {
+		t.Errorf("TestMixin: Expected 0 collisions, got %v\n%v", len(collisions), collisions)
 	}
 
 }


### PR DESCRIPTION
The un-initialized data structs resulted from from loading an ~empty primary spec.

Thanks for heads up on this added in issue #12