### PR TITLE
AllReferences should have same kind of output with AllRefs

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -723,9 +723,9 @@ func (s *Spec) AllItemsReferences() (result []string) {
 }
 
 // AllReferences returns all the references found in the document
-func (s *Spec) AllReferences() (result []string) {
+func (s *Spec) AllReferences() (result []spec.Ref) {
 	for _, v := range s.references.allRefs {
-		result = append(result, v.String())
+		result = append(result, v)
 	}
 	return
 }

--- a/mixin.go
+++ b/mixin.go
@@ -71,7 +71,7 @@ func Mixin(primary *spec.Swagger, mixins ...*spec.Swagger) []string {
 				// all the proivded specs are already unique.
 				piops := pathItemOps(v)
 				for _, piop := range piops {
-					if opIds[piop.ID] {
+					if piop.ID != "" && opIds[piop.ID] {
 						piop.ID = fmt.Sprintf("%v%v%v", piop.ID, "Mixin", i)
 					}
 					opIds[piop.ID] = true


### PR DESCRIPTION
Hi

In our project we need to merge multiple swagger documents and because there might be duplication of definition so we added prefix to definition. And then we need to update all references to those definitions and using AllRefs is not enough since it will only return unique references. So I think that maybe we can make AllReferences to return the same kind of output with AllRefs but with all references.

Thank you