### PR TITLE
JSON broken for object w/array of polymorphic types.

### DIFF
--- a/flatten.go
+++ b/flatten.go
@@ -88,7 +88,7 @@ func nameInlinedSchemas(opts *FlattenOpts) error {
 				return fmt.Errorf("schema analysis [%s]: %v", sch.Ref.String(), err)
 			}
 
-			if !asch.IsSimpleSchema { // complex schemas get moved
+			if !asch.IsSimpleSchema && !asch.IsArray { // complex schemas get moved
 				if err := namer.Name(key, sch.Schema, asch); err != nil {
 					return err
 				}

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -511,13 +511,9 @@ func TestNameInlinedSchemas(t *testing.T) {
 		Location string
 		Ref      spec.Ref
 	}{
-		{"#/paths/~1some~1where~1{id}/parameters/1/schema/items", "#/definitions/postSomeWhereIdParamsBody/items", spec.MustCreateRef("#/definitions/postSomeWhereIdParamsBodyItems")},
-		{"#/paths/~1some~1where~1{id}/parameters/1/schema", "#/paths/~1some~1where~1{id}/parameters/1/schema", spec.MustCreateRef("#/definitions/postSomeWhereIdParamsBody")},
 		{"#/paths/~1some~1where~1{id}/get/parameters/2/schema/properties/record/items/2/properties/name", "#/definitions/getSomeWhereIdParamsBodyRecordItems2/properties/name", spec.MustCreateRef("#/definitions/getSomeWhereIdParamsBodyRecordItems2Name")},
 		{"#/paths/~1some~1where~1{id}/get/parameters/2/schema/properties/record/items/1", "#/definitions/getSomeWhereIdParamsBodyRecord/items/1", spec.MustCreateRef("#/definitions/getSomeWhereIdParamsBodyRecordItems1")},
 		{"#/paths/~1some~1where~1{id}/get/parameters/2/schema/properties/record/items/2", "#/definitions/getSomeWhereIdParamsBodyRecord/items/2", spec.MustCreateRef("#/definitions/getSomeWhereIdParamsBodyRecordItems2")},
-		{"#/paths/~1some~1where~1{id}/get/parameters/2/schema/properties/record", "#/definitions/getSomeWhereIdParamsBodyOAIGen/properties/record", spec.MustCreateRef("#/definitions/getSomeWhereIdParamsBodyRecord")},
-		{"#/paths/~1some~1where~1{id}/get/parameters/2/schema", "#/paths/~1some~1where~1{id}/get/parameters/2/schema", spec.MustCreateRef("#/definitions/getSomeWhereIdParamsBodyOAIGen")},
 		{"#/paths/~1some~1where~1{id}/get/responses/200/schema/properties/record/items/2/properties/name", "#/definitions/getSomeWhereIdOKBodyRecordItems2/properties/name", spec.MustCreateRef("#/definitions/getSomeWhereIdOKBodyRecordItems2Name")},
 		{"#/paths/~1some~1where~1{id}/get/responses/200/schema/properties/record/items/1", "#/definitions/getSomeWhereIdOKBodyRecord/items/1", spec.MustCreateRef("#/definitions/getSomeWhereIdOKBodyRecordItems1")},
 		{"#/paths/~1some~1where~1{id}/get/responses/200/schema/properties/record/items/2", "#/definitions/getSomeWhereIdOKBodyRecord/items/2", spec.MustCreateRef("#/definitions/getSomeWhereIdOKBodyRecordItems2")},
@@ -585,7 +581,7 @@ func TestNameInlinedSchemas(t *testing.T) {
 				if rr.Schema != nil && rr.Schema.Ref.String() == "" && !rr.TopLevel {
 					asch, err := Schema(SchemaOpts{Schema: rr.Schema, Root: sp, BasePath: bp})
 					if assert.NoError(t, err, "for key: %s", k) {
-						if !asch.IsSimpleSchema {
+						if !asch.IsSimpleSchema && !asch.IsArray {
 							assert.Fail(t, "not a top level schema", "for key: %s", k)
 						}
 					}


### PR DESCRIPTION
https://github.com/go-swagger/go-swagger/issues/1336

When creating names for complex inline schemas, don't create a separate name
for an array of objects within an object.  It breaks the JSON marshalling
and unmarshalling if that array is of objects of a polymorphic type.

Signed-off-by: Greg Marr <greg.marr@autodesk.com>