### PR TITLE
Extends mixin

### DIFF
--- a/fixer.go
+++ b/fixer.go
@@ -1,0 +1,76 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import "github.com/go-openapi/spec"
+
+// FixEmptyResponseDescriptions replaces empty ("") response
+// descriptions in the input with "(empty)" to ensure that the
+// resulting Swagger is stays valid.  The problem appears to arise
+// from reading in valid specs that have a explicit response
+// description of "" (valid, response.description is required), but
+// due to zero values being omitted upon re-serializing (omitempty) we
+// lose them unless we stick some chars in there.
+func FixEmptyResponseDescriptions(s *spec.Swagger) {
+	if s.Paths != nil {
+		for _, v := range s.Paths.Paths {
+			if v.Get != nil {
+				FixEmptyDescs(v.Get.Responses)
+			}
+			if v.Put != nil {
+				FixEmptyDescs(v.Put.Responses)
+			}
+			if v.Post != nil {
+				FixEmptyDescs(v.Post.Responses)
+			}
+			if v.Delete != nil {
+				FixEmptyDescs(v.Delete.Responses)
+			}
+			if v.Options != nil {
+				FixEmptyDescs(v.Options.Responses)
+			}
+			if v.Head != nil {
+				FixEmptyDescs(v.Head.Responses)
+			}
+			if v.Patch != nil {
+				FixEmptyDescs(v.Patch.Responses)
+			}
+		}
+	}
+	for k, v := range s.Responses {
+		FixEmptyDesc(&v)
+		s.Responses[k] = v
+	}
+}
+
+// FixEmptyDescs adds "(empty)" as the description for any Response in
+// the given Responses object that doesn't already have one.
+func FixEmptyDescs(rs *spec.Responses) {
+	FixEmptyDesc(rs.Default)
+	for k, v := range rs.StatusCodeResponses {
+		FixEmptyDesc(&v)
+		rs.StatusCodeResponses[k] = v
+	}
+}
+
+// FixEmptyDesc adds "(empty)" as the description to the given
+// Response object if it doesn't already have one and isn't a
+// ref. No-op on nil input.
+func FixEmptyDesc(rs *spec.Response) {
+	if rs == nil || rs.Description != "" || rs.Ref.Ref.GetURL() != nil {
+		return
+	}
+	rs.Description = "(empty)"
+}

--- a/fixtures/other-mixin.yml
+++ b/fixtures/other-mixin.yml
@@ -1,0 +1,23 @@
+---
+swagger: '2.0'
+info:
+  title: extension of tags, schemes and consumes/produces
+  version: 4.2.0
+schemes:
+  - http
+  - https
+basePath: /api
+consumes:
+  - application/json
+  - application/octet-stream
+produces:
+  - application/json
+  - application/xml
+tags:
+  - name: ticket
+    description: operations to get and store tickets
+  - name: game
+    description: operations to follow games
+  - name: conflict
+    description: a tag in conflict with primary spec
+paths:

--- a/fixtures/securitydef.yml
+++ b/fixtures/securitydef.yml
@@ -1,0 +1,33 @@
+---
+swagger: '2.0'
+info:
+  title: extension of securityDefinitions
+  version: 4.2.0
+schemes:
+  - http
+basePath: /api
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  myOtherRoles:
+    description: definition of scopes as roles
+    type: oauth2
+    flow: accessCode 
+    authorizationUrl: https://foo.bar.com/authorize
+    tokenUrl: https://foo.bar.com/token
+    scopes:
+      otherSellers: group of sellers
+      otherBuyers: group of buyers
+  mySecondaryApiKey:
+    type: apiKey
+    name: X-secondaryApiKey
+    in: header
+  myBasicAuth:
+    type: basic
+    description: basic primary auth
+security:
+  - myBasicAuth: []
+
+paths:

--- a/fixtures/widget-crud.yml
+++ b/fixtures/widget-crud.yml
@@ -10,6 +10,33 @@ consumes:
   - application/json
 produces:
   - application/json
+securityDefinitions:
+  myRoles:
+    description: definition of scopes as roles
+    type: oauth2
+    flow: accessCode 
+    authorizationUrl: https://foo.bar.com/authorize
+    tokenUrl: https://foo.bar.com/token
+    scopes:
+      sellers: group of sellers
+      buyers: group of buyers
+  myPrimaryAPIKey:
+    type: apiKey
+    name: X-primaryApiKey
+    in: header
+  myBasicAuth:
+    type: basic
+    description: basic primary auth
+security:
+  - myPrimaryAPIKey: []
+  - 
+    myBasicAuth: []
+    myRoles: [ sellers ]
+  - 
+    myBasicAuth: []
+tags:
+  - name: conflict
+    description: a tag in conflict with primary spec
 paths:
   /common:
     get:

--- a/flatten.go
+++ b/flatten.go
@@ -1,3 +1,17 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analysis
 
 import (
@@ -73,7 +87,7 @@ func Flatten(opts FlattenOpts) error {
 	}
 	opts.Spec.reload() // re-analyze
 
-	// TODO: simplifiy known schema patterns to flat objects with properties?
+	// TODO: simplify known schema patterns to flat objects with properties?
 	return nil
 }
 
@@ -333,10 +347,7 @@ func (s splitKey) isKeyName(i int) bool {
 		count++
 	}
 
-	if count%2 != 0 {
-		return true
-	}
-	return false
+	return count%2 != 0
 }
 
 func (s splitKey) BuildName(segments []string, startIndex int, aschema *AnalyzedSchema) string {

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -1,3 +1,17 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analysis
 
 import (
@@ -501,6 +515,10 @@ func TestNameInlinedSchemas(t *testing.T) {
 	cwd, _ := os.Getwd()
 	bp := filepath.Join(cwd, "fixtures", "nested_inline_schemas.yml")
 	sp, err := loadSpec(bp)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+		return
+	}
 	err = spec.ExpandSpec(sp, &spec.ExpandOptions{
 		RelativeBase: bp,
 		SkipSchemas:  true,

--- a/mixin.go
+++ b/mixin.go
@@ -1,7 +1,22 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analysis
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/go-openapi/spec"
 )
@@ -10,158 +25,60 @@ import (
 // definitions from the mixin specs. Top level parameters and
 // responses from the mixins are also carried over. Operation id
 // collisions are avoided by appending "Mixin<N>" but only if
-// needed. No other parts of primary are modified. Consider calling
-// FixEmptyResponseDescriptions() on the modified primary if you read
-// them from storage and they are valid to start with.
+// needed.
+//
+// The following parts of primary are never modified by merging:
+//   - Info
+//   - BasePath
+//   - Host
+//   - ExternalDocs
+//
+// Consider calling FixEmptyResponseDescriptions() on the modified primary
+// if you read them from storage and they are valid to start with.
 //
 // Entries in "paths", "definitions", "parameters" and "responses" are
 // added to the primary in the order of the given mixins. If the entry
 // already exists in primary it is skipped with a warning message.
 //
 // The count of skipped entries (from collisions) is returned so any
-// deviation from the number expected can flag warning in your build
+// deviation from the number expected can flag a warning in your build
 // scripts. Carefully review the collisions before accepting them;
 // consider renaming things if possible.
 //
 // No normalization of any keys takes place (paths, type defs,
 // etc). Ensure they are canonical if your downstream tools do
 // key normalization of any form.
+//
+// Merging schemes (http, https), and consumers/producers do not account for
+// collisions.
 func Mixin(primary *spec.Swagger, mixins ...*spec.Swagger) []string {
 	var skipped []string
 	opIds := getOpIds(primary)
-	if primary.Paths == nil {
-		primary.Paths = &spec.Paths{Paths: make(map[string]spec.PathItem)}
-	}
-	if primary.Paths.Paths == nil {
-		primary.Paths.Paths = make(map[string]spec.PathItem)
-	}
-	if primary.Definitions == nil {
-		primary.Definitions = make(spec.Definitions)
-	}
-	if primary.Parameters == nil {
-		primary.Parameters = make(map[string]spec.Parameter)
-	}
-	if primary.Responses == nil {
-		primary.Responses = make(map[string]spec.Response)
-	}
+	initPrimary(primary)
 
 	for i, m := range mixins {
-		for k, v := range m.Definitions {
-			// assume name collisions represent IDENTICAL type. careful.
-			if _, exists := primary.Definitions[k]; exists {
-				warn := fmt.Sprintf("definitions entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
-				skipped = append(skipped, warn)
-				continue
-			}
-			primary.Definitions[k] = v
-		}
-		if m.Paths != nil {
-			for k, v := range m.Paths.Paths {
-				if _, exists := primary.Paths.Paths[k]; exists {
-					warn := fmt.Sprintf("paths entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
-					skipped = append(skipped, warn)
-					continue
-				}
+		skipped = append(skipped, mergeConsumes(primary, m)...)
 
-				// Swagger requires that operationIds be
-				// unique within a spec. If we find a
-				// collision we append "Mixin0" to the
-				// operatoinId we are adding, where 0 is mixin
-				// index.  We assume that operationIds with
-				// all the proivded specs are already unique.
-				piops := pathItemOps(v)
-				for _, piop := range piops {
-					if opIds[piop.ID] {
-						piop.ID = fmt.Sprintf("%v%v%v", piop.ID, "Mixin", i)
-					}
-					opIds[piop.ID] = true
-				}
-				primary.Paths.Paths[k] = v
-			}
-		}
-		for k, v := range m.Parameters {
-			// could try to rename on conflict but would
-			// have to fix $refs in the mixin. Complain
-			// for now
-			if _, exists := primary.Parameters[k]; exists {
-				warn := fmt.Sprintf("top level parameters entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
-				skipped = append(skipped, warn)
-				continue
-			}
-			primary.Parameters[k] = v
-		}
-		for k, v := range m.Responses {
-			// could try to rename on conflict but would
-			// have to fix $refs in the mixin. Complain
-			// for now
-			if _, exists := primary.Responses[k]; exists {
-				warn := fmt.Sprintf("top level responses entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
-				skipped = append(skipped, warn)
-				continue
-			}
-			primary.Responses[k] = v
-		}
+		skipped = append(skipped, mergeProduces(primary, m)...)
+
+		skipped = append(skipped, mergeTags(primary, m)...)
+
+		skipped = append(skipped, mergeSchemes(primary, m)...)
+
+		skipped = append(skipped, mergeSecurityDefinitions(primary, m)...)
+
+		skipped = append(skipped, mergeSecurityRequirements(primary, m)...)
+
+		skipped = append(skipped, mergeDefinitions(primary, m)...)
+
+		// merging paths requires a map of operationIDs to work with
+		skipped = append(skipped, mergePaths(primary, m, opIds, i)...)
+
+		skipped = append(skipped, mergeParameters(primary, m)...)
+
+		skipped = append(skipped, mergeResponses(primary, m)...)
 	}
 	return skipped
-}
-
-// FixEmptyResponseDescriptions replaces empty ("") response
-// descriptions in the input with "(empty)" to ensure that the
-// resulting Swagger is stays valid.  The problem appears to arise
-// from reading in valid specs that have a explicit response
-// description of "" (valid, response.description is required), but
-// due to zero values being omitted upon re-serializing (omitempty) we
-// lose them unless we stick some chars in there.
-func FixEmptyResponseDescriptions(s *spec.Swagger) {
-	if s.Paths != nil {
-		for _, v := range s.Paths.Paths {
-			if v.Get != nil {
-				FixEmptyDescs(v.Get.Responses)
-			}
-			if v.Put != nil {
-				FixEmptyDescs(v.Put.Responses)
-			}
-			if v.Post != nil {
-				FixEmptyDescs(v.Post.Responses)
-			}
-			if v.Delete != nil {
-				FixEmptyDescs(v.Delete.Responses)
-			}
-			if v.Options != nil {
-				FixEmptyDescs(v.Options.Responses)
-			}
-			if v.Head != nil {
-				FixEmptyDescs(v.Head.Responses)
-			}
-			if v.Patch != nil {
-				FixEmptyDescs(v.Patch.Responses)
-			}
-		}
-	}
-	for k, v := range s.Responses {
-		FixEmptyDesc(&v)
-		s.Responses[k] = v
-	}
-}
-
-// FixEmptyDescs adds "(empty)" as the description for any Response in
-// the given Responses object that doesn't already have one.
-func FixEmptyDescs(rs *spec.Responses) {
-	FixEmptyDesc(rs.Default)
-	for k, v := range rs.StatusCodeResponses {
-		FixEmptyDesc(&v)
-		rs.StatusCodeResponses[k] = v
-	}
-}
-
-// FixEmptyDesc adds "(empty)" as the description to the given
-// Response object if it doesn't already have one and isn't a
-// ref. No-op on nil input.
-func FixEmptyDesc(rs *spec.Response) {
-	if rs == nil || rs.Description != "" || rs.Ref.Ref.GetURL() != nil {
-		return
-	}
-	rs.Description = "(empty)"
 }
 
 // getOpIds extracts all the paths.<path>.operationIds from the given
@@ -196,4 +113,215 @@ func appendOp(ops []*spec.Operation, op *spec.Operation) []*spec.Operation {
 		return ops
 	}
 	return append(ops, op)
+}
+
+func mergeSecurityDefinitions(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for k, v := range m.SecurityDefinitions {
+		if _, exists := primary.SecurityDefinitions[k]; exists {
+			warn := fmt.Sprintf("SecurityDefinitions entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+			skipped = append(skipped, warn)
+			continue
+		}
+		primary.SecurityDefinitions[k] = v
+	}
+	return
+}
+
+func mergeSecurityRequirements(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for _, v := range m.Security {
+		found := false
+		for _, vv := range primary.Security {
+			if reflect.DeepEqual(v, vv) {
+				found = true
+				break
+			}
+		}
+		if found {
+			warn := fmt.Sprintf("Security requirement: '%v' already exists in primary or higher priority mixin, skipping\n", v)
+			skipped = append(skipped, warn)
+			continue
+		}
+		primary.Security = append(primary.Security, v)
+	}
+	return
+}
+
+func mergeDefinitions(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for k, v := range m.Definitions {
+		// assume name collisions represent IDENTICAL type. careful.
+		if _, exists := primary.Definitions[k]; exists {
+			warn := fmt.Sprintf("definitions entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+			skipped = append(skipped, warn)
+			continue
+		}
+		primary.Definitions[k] = v
+	}
+	return
+}
+
+func mergePaths(primary *spec.Swagger, m *spec.Swagger, opIds map[string]bool, mixIndex int) (skipped []string) {
+	if m.Paths != nil {
+		for k, v := range m.Paths.Paths {
+			if _, exists := primary.Paths.Paths[k]; exists {
+				warn := fmt.Sprintf("paths entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+				skipped = append(skipped, warn)
+				continue
+			}
+
+			// Swagger requires that operationIds be
+			// unique within a spec. If we find a
+			// collision we append "Mixin0" to the
+			// operatoinId we are adding, where 0 is mixin
+			// index.  We assume that operationIds with
+			// all the proivded specs are already unique.
+			piops := pathItemOps(v)
+			for _, piop := range piops {
+				if opIds[piop.ID] {
+					piop.ID = fmt.Sprintf("%v%v%v", piop.ID, "Mixin", mixIndex)
+				}
+				opIds[piop.ID] = true
+			}
+			primary.Paths.Paths[k] = v
+		}
+	}
+	return
+}
+
+func mergeParameters(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for k, v := range m.Parameters {
+		// could try to rename on conflict but would
+		// have to fix $refs in the mixin. Complain
+		// for now
+		if _, exists := primary.Parameters[k]; exists {
+			warn := fmt.Sprintf("top level parameters entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+			skipped = append(skipped, warn)
+			continue
+		}
+		primary.Parameters[k] = v
+	}
+	return
+}
+
+func mergeResponses(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for k, v := range m.Responses {
+		// could try to rename on conflict but would
+		// have to fix $refs in the mixin. Complain
+		// for now
+		if _, exists := primary.Responses[k]; exists {
+			warn := fmt.Sprintf("top level responses entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+			skipped = append(skipped, warn)
+			continue
+		}
+		primary.Responses[k] = v
+	}
+	return
+}
+
+func mergeConsumes(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for _, v := range m.Consumes {
+		found := false
+		for _, vv := range primary.Consumes {
+			if v == vv {
+				found = true
+				break
+			}
+		}
+		if found {
+			// no warning here: we just skip it
+			continue
+		}
+		primary.Consumes = append(primary.Consumes, v)
+	}
+	return
+}
+
+func mergeProduces(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for _, v := range m.Produces {
+		found := false
+		for _, vv := range primary.Produces {
+			if v == vv {
+				found = true
+				break
+			}
+		}
+		if found {
+			// no warning here: we just skip it
+			continue
+		}
+		primary.Produces = append(primary.Produces, v)
+	}
+	return
+}
+
+func mergeTags(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for _, v := range m.Tags {
+		found := false
+		for _, vv := range primary.Tags {
+			if v.Name == vv.Name {
+				found = true
+				break
+			}
+		}
+		if found {
+			warn := fmt.Sprintf("top level tags entry with name '%v' already exists in primary or higher priority mixin, skipping\n", v.Name)
+			skipped = append(skipped, warn)
+			continue
+		}
+		primary.Tags = append(primary.Tags, v)
+	}
+	return
+}
+
+func mergeSchemes(primary *spec.Swagger, m *spec.Swagger) (skipped []string) {
+	for _, v := range m.Schemes {
+		found := false
+		for _, vv := range primary.Schemes {
+			if v == vv {
+				found = true
+				break
+			}
+		}
+		if found {
+			// no warning here: we just skip it
+			continue
+		}
+		primary.Schemes = append(primary.Schemes, v)
+	}
+	return
+}
+
+func initPrimary(primary *spec.Swagger) {
+	if primary.SecurityDefinitions == nil {
+		primary.SecurityDefinitions = make(map[string]*spec.SecurityScheme)
+	}
+	if primary.Security == nil {
+		primary.Security = make([]map[string][]string, 0, 10)
+	}
+	if primary.Produces == nil {
+		primary.Produces = make([]string, 0, 10)
+	}
+	if primary.Consumes == nil {
+		primary.Consumes = make([]string, 0, 10)
+	}
+	if primary.Tags == nil {
+		primary.Tags = make([]spec.Tag, 0, 10)
+	}
+	if primary.Schemes == nil {
+		primary.Schemes = make([]string, 0, 10)
+	}
+	if primary.Paths == nil {
+		primary.Paths = &spec.Paths{Paths: make(map[string]spec.PathItem)}
+	}
+	if primary.Paths.Paths == nil {
+		primary.Paths.Paths = make(map[string]spec.PathItem)
+	}
+	if primary.Definitions == nil {
+		primary.Definitions = make(spec.Definitions)
+	}
+	if primary.Parameters == nil {
+		primary.Parameters = make(map[string]spec.Parameter)
+	}
+	if primary.Responses == nil {
+		primary.Responses = make(map[string]spec.Response)
+	}
 }

--- a/mixin_test.go
+++ b/mixin_test.go
@@ -1,6 +1,22 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analysis
 
-import "testing"
+import (
+	"testing"
+)
 
 const (
 	widgetFile     = "fixtures/widget-crud.yml"
@@ -8,6 +24,8 @@ const (
 	barFile        = "fixtures/bar-crud.yml"
 	noPathsFile    = "fixtures/no-paths.yml"
 	emptyPathsFile = "fixtures/empty-paths.json"
+	securityFile   = "fixtures/securitydef.yml"
+	otherMixin     = "fixtures/other-mixin.yml"
 )
 
 func TestMixin(t *testing.T) {
@@ -28,10 +46,19 @@ func TestMixin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not load '%v': %v\n", noPathsFile, err)
 	}
+	mixin4, err := loadSpec(securityFile)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", securityFile, err)
+	}
 
-	collisions := Mixin(primary, mixin1, mixin2, mixin3)
-	if len(collisions) != 16 {
-		t.Errorf("TestMixin: Expected 16 collisions, got %v\n%v", len(collisions), collisions)
+	mixin5, err := loadSpec(otherMixin)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", otherMixin, err)
+	}
+
+	collisions := Mixin(primary, mixin1, mixin2, mixin3, mixin4, mixin5)
+	if len(collisions) != 19 {
+		t.Errorf("TestMixin: Expected 19 collisions, got %v\n%v", len(collisions), collisions)
 	}
 
 	if len(primary.Paths.Paths) != 7 {
@@ -50,6 +77,30 @@ func TestMixin(t *testing.T) {
 		t.Errorf("TestMixin: Expected 2 top level responses in merged, got %v\n", len(primary.Responses))
 	}
 
+	if len(primary.SecurityDefinitions) != 5 {
+		t.Errorf("TestMixin: Expected 5 top level SecurityDefinitions in merged, got %v\n", len(primary.SecurityDefinitions))
+	}
+
+	if len(primary.Security) != 3 {
+		t.Errorf("TestMixin: Expected 3 top level Security requirements in merged, got %v\n", len(primary.Security))
+	}
+
+	if len(primary.Tags) != 3 {
+		t.Errorf("TestMixin: Expected 3 top level tags merged, got %v\n", len(primary.Security))
+	}
+
+	if len(primary.Schemes) != 2 {
+		t.Errorf("TestMixin: Expected 2 top level schemes merged, got %v\n", len(primary.Security))
+	}
+
+	if len(primary.Consumes) != 2 {
+		t.Errorf("TestMixin: Expected 2 top level Consumers merged, got %v\n", len(primary.Security))
+	}
+
+	if len(primary.Produces) != 2 {
+		t.Errorf("TestMixin: Expected 2 top level Producers merged, got %v\n", len(primary.Security))
+	}
+
 	// test that adding paths to a primary with no paths works (was NPE)
 	emptyPaths, err := loadSpec(emptyPathsFile)
 	if err != nil {
@@ -60,5 +111,26 @@ func TestMixin(t *testing.T) {
 	if len(collisions) != 0 {
 		t.Errorf("TestMixin: Expected 0 collisions, got %v\n%v", len(collisions), collisions)
 	}
+	//bbb, _ := json.MarshalIndent(primary, "", " ")
+	//t.Log(string(bbb))
+}
 
+func TestMixinFromNilPath(t *testing.T) {
+	primary, err := loadSpec(otherMixin)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", otherMixin, err)
+	}
+	mixin1, err := loadSpec(widgetFile)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", widgetFile, err)
+	}
+	collisions := Mixin(primary, mixin1)
+	if len(collisions) != 1 {
+		t.Errorf("TestMixin: Expected 1 collisions, got %v\n%v", len(collisions), collisions)
+	}
+	if len(primary.Paths.Paths) != 3 {
+		t.Errorf("TestMixin: Expected 3 paths in merged, got %v\n", len(primary.Paths.Paths))
+	}
+	//bbb, _ := json.MarshalIndent(primary.Paths.Paths, "", " ")
+	//t.Log(string(bbb))
 }


### PR DESCRIPTION
* Extends mixin spec to top level definitions: schemes, tags, produces, consumes, securityDefinition and security requirements
* Refactored mixin and extended UT
* Moved spec fix to dedicated source file
* A little linting after a gometalinter pass
* Added missing copyrights in source

Contributes to:
* go-swagger/go-swagger#1471