### PR TITLE
Empty security requirements

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -421,7 +421,7 @@ func (s *Spec) SecurityRequirementsFor(operation *spec.Operation) [][]SecurityRe
 		schemes = operation.Security
 	}
 
-	var result [][]SecurityRequirement
+	result := [][]SecurityRequirement{}
 	for _, scheme := range schemes {
 		if len(scheme) == 0 {
 			// append a zero object for anonymous

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -633,9 +633,12 @@ func TestSecurityRequirements(t *testing.T) {
 	require.Empty(t, reqs2[1][0].Name)
 	require.Empty(t, reqs2[1][0].Scopes)
 	require.Len(t, reqs2[2], 2)
-	require.Equal(t, reqs2[2][0].Name, "basic")
+	//
+	//require.Equal(t, reqs2[2][0].Name, "basic")
+	require.Contains(t, reqs2[2], SecurityRequirement{Name: "basic", Scopes: []string{}})
 	require.Empty(t, reqs2[2][0].Scopes)
-	require.Equal(t, reqs2[2][1].Name, "apiKey")
+	//require.Equal(t, reqs2[2][1].Name, "apiKey")
+	require.Contains(t, reqs2[2], SecurityRequirement{Name: "apiKey", Scopes: []string{}})
 	require.Empty(t, reqs2[2][1].Scopes)
 }
 


### PR DESCRIPTION
- fix empty security requirements mismatch with nil (return empty slice instead of nil,
when operation overrides global security requirements
- fix unstable unit test, as inner requirements are not ordered