### PR TITLE
Fix array vs tuple detection

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -160,23 +160,15 @@ func (a *AnalyzedSchema) inferMap() error {
 }
 
 func (a *AnalyzedSchema) inferArray() error {
-	fromValid := a.isArrayType() && (a.schema.Items == nil || a.schema.Items.Len() < 2)
-	a.IsArray = fromValid || (a.hasItems && a.schema.Items.Len() < 2)
+	// an array has Items defined as an object schema, otherwise we qualify this JSON array as a tuple
+	// (yes, even if the Items array contains only one element).
+	// arrays in JSON schema may be unrestricted (i.e no Items specified).
+	// Note that arrays in Swagger MUST have Items. Nonetheless, we analyze unrestricted arrays.
+	a.IsArray = a.isArrayType() && (a.schema.Items == nil || a.schema.Items.Schema != nil)
 	if a.IsArray && a.hasItems {
 		if a.schema.Items.Schema != nil {
 			itsch, err := Schema(SchemaOpts{
 				Schema:   a.schema.Items.Schema,
-				Root:     a.root,
-				BasePath: a.basePath,
-			})
-			if err != nil {
-				return err
-			}
-			a.IsSimpleArray = itsch.IsSimpleSchema
-		}
-		if len(a.schema.Items.Schemas) > 0 {
-			itsch, err := Schema(SchemaOpts{
-				Schema:   &a.schema.Items.Schemas[0],
 				Root:     a.root,
 				BasePath: a.basePath,
 			})
@@ -193,7 +185,7 @@ func (a *AnalyzedSchema) inferArray() error {
 }
 
 func (a *AnalyzedSchema) inferTuple() error {
-	tuple := a.hasItems && a.schema.Items.Len() > 1
+	tuple := a.hasItems && a.schema.Items.Schemas != nil
 	a.IsTuple = tuple && !a.hasAdditionalItems
 	a.IsTupleWithExtra = tuple && a.hasAdditionalItems
 	return nil

--- a/schema_test.go
+++ b/schema_test.go
@@ -165,6 +165,16 @@ func TestSchemaAnalysis_Array(t *testing.T) {
 		}
 	}
 
+	// edge case: unrestricted array (beyond Swagger)
+	at := spec.ArrayProperty(nil)
+	at.Items = nil
+	sch, err := Schema(SchemaOpts{Schema: at})
+	if assert.NoError(t, err) {
+		assert.True(t, sch.IsArray)
+		assert.False(t, sch.IsTuple)
+		assert.False(t, sch.IsKnownType)
+		assert.True(t, sch.IsSimpleSchema)
+	}
 }
 
 func TestSchemaAnalysis_Map(t *testing.T) {
@@ -203,6 +213,17 @@ func TestSchemaAnalysis_Tuple(t *testing.T) {
 	at.Items.Schemas = append(at.Items.Schemas, *spec.StringProperty(), *spec.Int64Property())
 
 	sch, err := Schema(SchemaOpts{Schema: at})
+	if assert.NoError(t, err) {
+		assert.True(t, sch.IsTuple)
+		assert.False(t, sch.IsTupleWithExtra)
+		assert.False(t, sch.IsKnownType)
+		assert.False(t, sch.IsSimpleSchema)
+	}
+
+	// edge case: tuple with a single element
+	at.Items = &spec.SchemaOrArray{}
+	at.Items.Schemas = append(at.Items.Schemas, *spec.StringProperty())
+	sch, err = Schema(SchemaOpts{Schema: at})
 	if assert.NoError(t, err) {
 		assert.True(t, sch.IsTuple)
 		assert.False(t, sch.IsTupleWithExtra)


### PR DESCRIPTION
Fix edge case with tuple definition with a single element
We must check tuple using .Schemas != nil rather than (*SchemaOrArray) Len().

The following definition:
```yaml
type: array
items:
- type: integer
``` 
should be considered a tuple and not an array.

> NOTE: this story about tuples is always a bit edgy. So I confirmed my views by validating this using `ajv` 