### PR TITLE
Fix flatten with pointers containing escaped chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 secrets.yml
 coverage.out
+coverage.txt
+*.cov
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: go
 go:
-- 1.7
 - 1.8
 - 1.9
 - 1.10.x
 install:
+- go get -u github.com/axw/gocov/gocov
+- go get -u gopkg.in/matm/v1/gocov-html
+- go get -u github.com/cee-dub/go-junit-report
+- go get -u github.com/docker/go-units
 - go get -u github.com/stretchr/testify/assert
 - go get -u gopkg.in/yaml.v2
 - go get -u github.com/go-openapi/swag
@@ -13,7 +16,7 @@ install:
 - go get -u github.com/go-openapi/strfmt
 - go get -u github.com/go-openapi/loads/fmts
 script:
-- go test -v -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
+- hack/coverage
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 notifications:

--- a/fixtures/bugs/1602/fixture-1602-6.yaml
+++ b/fixtures/bugs/1602/fixture-1602-6.yaml
@@ -1,0 +1,40 @@
+---
+swagger: "2.0"
+schemes:
+  - "http"
+  - "https"
+basePath: "/v1.24"
+info:
+  title: "derived from Pouch Engine API"
+  version: "1.24"
+  description: A variation on issue go-swagger/go-swagger#1609
+paths:
+  /_ping:
+    get:
+      responses:
+        401:
+          description: an error
+          schema:
+            $ref: "#/responses/401ValidSchema"
+        404:
+          description: another error
+          schema:
+            $ref: "#/parameters/bodyValidSchema"
+        500:
+          $ref: "#/responses/401ValidSchema"
+
+definitions:
+  Error:
+    type: "object"
+    properties:
+      message:
+        type: string
+
+parameters:
+  bodyValidSchema:
+    description: a valid schema (but invalid parameter)
+    type: string
+
+responses:
+  401ValidSchema:
+    description: An unexpected 401 error occurred.

--- a/fixtures/bugs/1614/gitea.yaml
+++ b/fixtures/bugs/1614/gitea.yaml
@@ -1,0 +1,5854 @@
+---
+  consumes: 
+    - "application/json"
+    - "text/plain"
+  produces: 
+    - "application/json"
+    - "text/html"
+  schemes: 
+    - "http"
+    - "https"
+  swagger: "2.0"
+  info: 
+    description: "This documentation describes the Gitea API."
+    title: "Gitea API."
+    license: 
+      name: "MIT"
+      url: "http://opensource.org/licenses/MIT"
+    version: "1.1.1"
+  basePath: "/api/v1"
+  paths: 
+    /admin/users: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "admin"
+        summary: "Create a user"
+        operationId: "adminCreateUser"
+        parameters: 
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateUserOption"
+        responses: 
+          201: 
+            $ref: "#/responses/User"
+          403: 
+            $ref: "#/responses/forbidden"
+          422: 
+            $ref: "#/responses/validationError"
+    /admin/users/{username}: 
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "admin"
+        summary: "Delete a user"
+        operationId: "adminDeleteUser"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user to delete"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          403: 
+            $ref: "#/responses/forbidden"
+          422: 
+            $ref: "#/responses/validationError"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "admin"
+        summary: "Edit an existing user"
+        operationId: "adminEditUser"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user to edit"
+            name: "username"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditUserOption"
+        responses: 
+          200: 
+            $ref: "#/responses/User"
+          403: 
+            $ref: "#/responses/forbidden"
+          422: 
+            $ref: "#/responses/validationError"
+    /admin/users/{username}/keys: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "admin"
+        summary: "Add a public key on behalf of a user"
+        operationId: "adminCreatePublicKey"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of the user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          201: 
+            $ref: "#/responses/PublicKey"
+          403: 
+            $ref: "#/responses/forbidden"
+          422: 
+            $ref: "#/responses/validationError"
+    /admin/users/{username}/keys/{id}: 
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "admin"
+        summary: "Delete a user's public key"
+        operationId: "adminDeleteUserPublicKey"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the key to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          403: 
+            $ref: "#/responses/forbidden"
+          404: 
+            $ref: "#/responses/notFound"
+    /admin/users/{username}/orgs: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "admin"
+        summary: "Create an organization"
+        operationId: "adminCreateOrg"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of the user that will own the created organization"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          201: 
+            $ref: "#/responses/Organization"
+          403: 
+            $ref: "#/responses/forbidden"
+          422: 
+            $ref: "#/responses/validationError"
+    /admin/users/{username}/repos: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "admin"
+        summary: "Create a repository on behalf a user"
+        operationId: "adminCreateRepo"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of the user. This user will own the created repository"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          201: 
+            $ref: "#/responses/Repository"
+          403: 
+            $ref: "#/responses/forbidden"
+          422: 
+            $ref: "#/responses/validationError"
+    /markdown: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "text/html"
+        tags: 
+          - "miscellaneous"
+        summary: "Render a markdown document as HTML"
+        operationId: "renderMarkdown"
+        parameters: 
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/MarkdownOption"
+        responses: 
+          200: 
+            $ref: "#/responses/MarkdownRender"
+          422: 
+            $ref: "#/responses/validationError"
+    /markdown/raw: 
+      post: 
+        consumes: 
+          - "text/plain"
+        produces: 
+          - "text/html"
+        tags: 
+          - "miscellaneous"
+        summary: "Render raw markdown as HTML"
+        operationId: "renderMarkdownRaw"
+        parameters: 
+          - 
+            description: "Request body to render"
+            name: "body"
+            in: "body"
+            required: true
+            schema: 
+              type: "string"
+        responses: 
+          200: 
+            $ref: "#/responses/MarkdownRender"
+          422: 
+            $ref: "#/responses/validationError"
+    /org/{org}/repos: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Create a repository in an organization"
+        operationId: "createOrgRepo"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateRepoOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Repository"
+          403: 
+            $ref: "#/responses/forbidden"
+          422: 
+            $ref: "#/responses/validationError"
+    /orgs/{org}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Get an organization"
+        operationId: "orgGet"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization to get"
+            name: "org"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Organization"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Edit an organization"
+        operationId: "orgEdit"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization to edit"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditOrgOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Organization"
+    /orgs/{org}/hooks: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List an organization's webhooks"
+        operationId: "orgListHooks"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/HookList"
+    /orgs/{org}/hooks/: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Create a hook"
+        operationId: "orgCreateHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+        responses: 
+          201: 
+            $ref: "#/responses/Hook"
+    /orgs/{org}/hooks/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Get a hook"
+        operationId: "orgGetHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the hook to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Hook"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Delete a hook"
+        operationId: "orgDeleteHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the hook to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Update a hook"
+        operationId: "orgEditHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the hook to update"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Hook"
+    /orgs/{org}/members: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List an organization's members"
+        operationId: "orgListMembers"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /orgs/{org}/members/{username}: 
+      get: 
+        tags: 
+          - "organization"
+        summary: "Check if a user is a member of an organization"
+        operationId: "orgIsMember"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            description: "user is a member"
+            schema: 
+              $ref: "#/responses/empty"
+          404: 
+            description: "user is not a member"
+            schema: 
+              $ref: "#/responses/empty"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Remove a member from an organization"
+        operationId: "orgDeleteMember"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            description: "member removed"
+            schema: 
+              $ref: "#/responses/empty"
+    /orgs/{org}/public_members: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List an organization's public members"
+        operationId: "orgListPublicMembers"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /orgs/{org}/public_members/{username}: 
+      get: 
+        tags: 
+          - "organization"
+        summary: "Check if a user is a public member of an organization"
+        operationId: "orgIsPublicMember"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            description: "user is a public member"
+            schema: 
+              $ref: "#/responses/empty"
+          404: 
+            description: "user is not a public member"
+            schema: 
+              $ref: "#/responses/empty"
+      put: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Publicize a user's membership"
+        operationId: "orgPublicizeMember"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            description: "membership publicized"
+            schema: 
+              $ref: "#/responses/empty"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Conceal a user's membership"
+        operationId: "orgConcealMember"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /orgs/{org}/repos: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List an organization's repos"
+        operationId: "orgListRepos"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+    /orgs/{org}/teams: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List an organization's teams"
+        operationId: "orgListTeams"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/TeamList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Create a team"
+        operationId: "orgCreateTeam"
+        parameters: 
+          - 
+            type: "string"
+            description: "name of the organization"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateTeamOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Team"
+    /repos/migrate: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Migrate a remote git repository"
+        operationId: "repoMigrate"
+        parameters: 
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/MigrateRepoForm"
+        responses: 
+          201: 
+            $ref: "#/responses/Repository"
+    /repos/search: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Search for repositories"
+        operationId: "repoSearch"
+        parameters: 
+          - 
+            type: "string"
+            description: "keyword"
+            name: "q"
+            in: "query"
+          - 
+            type: "integer"
+            description: "search only for repos that the user with the given id owns or contributes to"
+            name: "uid"
+            in: "query"
+          - 
+            type: "integer"
+            description: "page number of results to return (1-based)"
+            name: "page"
+            in: "query"
+          - 
+            type: "integer"
+            description: "page size of results, maximum page size is 50"
+            name: "limit"
+            in: "query"
+          - 
+            type: "string"
+            description: "type of repository to search for. Supported values are \"fork\", \"source\", \"mirror\" and \"collaborative\""
+            name: "mode"
+            in: "query"
+          - 
+            type: "boolean"
+            description: "if `uid` is given, search only for repos that the user owns"
+            name: "exclusive"
+            in: "query"
+        responses: 
+          200: 
+            $ref: "#/responses/SearchResults"
+          422: 
+            $ref: "#/responses/validationError"
+    /repos/{owner}/{repo}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a repository"
+        operationId: "repoGet"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Repository"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Delete a repository"
+        operationId: "repoDelete"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo to delete"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo to delete"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          403: 
+            $ref: "#/responses/forbidden"
+    /repos/{owner}/{repo}/archive/{archive}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get an archive of a repository"
+        operationId: "repoGetArchive"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "archive to download, consisting of a git reference and archive"
+            name: "archive"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            description: "success"
+    /repos/{owner}/{repo}/branches: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repository's branches"
+        operationId: "repoListBranches"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/BranchList"
+    /repos/{owner}/{repo}/branches/{branch}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repository's branches"
+        operationId: "repoGetBranch"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "branch to get"
+            name: "branch"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Branch"
+    /repos/{owner}/{repo}/collaborators: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repository's collaborators"
+        operationId: "repoListCollaborators"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /repos/{owner}/{repo}/collaborators/{collaborator}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Check if a user is a collaborator of a repository"
+        operationId: "repoCheckCollaborator"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the collaborator"
+            name: "collaborator"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          404: 
+            $ref: "#/responses/empty"
+      put: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Add a collaborator to a repository"
+        operationId: "repoAddCollaborator"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the collaborator to add"
+            name: "collaborator"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/AddCollaboratorOption"
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Delete a collaborator from a repository"
+        operationId: "repoDeleteCollaborator"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the collaborator to delete"
+            name: "collaborator"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/commits/{ref}/statuses: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a commit's combined status, by branch/tag/commit reference"
+        operationId: "repoGetCombinedStatusByRef"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of branch/tag/commit"
+            name: "ref"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Status"
+    /repos/{owner}/{repo}/editorconfig/{filepath}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get the EditorConfig definitions of a file in a repository"
+        operationId: "repoGetEditorConfig"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "filepath of file to get"
+            name: "filepath"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            description: "success"
+    /repos/{owner}/{repo}/forks: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repository's forks"
+        operationId: "listForks"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+      post: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Fork a repository"
+        operationId: "createFork"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo to fork"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo to fork"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateForkOption"
+        responses: 
+          202: 
+            $ref: "#/responses/Repository"
+    /repos/{owner}/{repo}/hooks: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List the hooks in a repository"
+        operationId: "repoListHooks"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/HookList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Create a hook"
+        operationId: "repoCreateHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateHookOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Hook"
+    /repos/{owner}/{repo}/hooks/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a hook"
+        operationId: "repoGetHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the hook to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Hook"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Delete a hook in a repository"
+        operationId: "repoDeleteHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the hook to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          404: 
+            $ref: "#/responses/notFound"
+      patch: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Edit a hook in a repository"
+        operationId: "repoEditHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the hook"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditHookOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Hook"
+    /repos/{owner}/{repo}/hooks/{id}/tests: 
+      post: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Test a push webhook"
+        operationId: "repoTestHook"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the hook to test"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/issues: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "List a repository's issues"
+        operationId: "issueListIssues"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "whether issue is open or closed"
+            name: "state"
+            in: "query"
+          - 
+            type: "integer"
+            description: "page number of requested issues"
+            name: "page"
+            in: "query"
+          - 
+            type: "string"
+            description: "search string"
+            name: "q"
+            in: "query"
+        responses: 
+          200: 
+            $ref: "#/responses/IssueList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Create an issue"
+        operationId: "issueCreateIssue"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateIssueOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Issue"
+    /repos/{owner}/{repo}/issues/comments: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "List all comments in a repository"
+        operationId: "issueGetRepoComments"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "if provided, only comments updated since the provided time are returned."
+            name: "since"
+            in: "query"
+        responses: 
+          200: 
+            $ref: "#/responses/CommentList"
+    /repos/{owner}/{repo}/issues/comments/{id}: 
+      delete: 
+        tags: 
+          - "issue"
+        summary: "Delete a comment"
+        operationId: "issueDeleteComment"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of comment to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Edit a comment"
+        operationId: "issueEditComment"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the comment to edit"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditIssueCommentOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Comment"
+    /repos/{owner}/{repo}/issues/{id}/times: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "List an issue's tracked times"
+        operationId: "issueTrackedTimes"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/TrackedTimeList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Add a tracked time to a issue"
+        operationId: "issueAddTime"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue to add tracked time to"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/AddTimeOption"
+        responses: 
+          200: 
+            $ref: "#/responses/TrackedTime"
+          400: 
+            $ref: "#/responses/error"
+          403: 
+            $ref: "#/responses/error"
+    /repos/{owner}/{repo}/issues/{index}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Get an issue"
+        operationId: "issueGetIssue"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue to get"
+            name: "index"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Issue"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Edit an issue"
+        operationId: "issueEditIssue"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue to edit"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditIssueOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Issue"
+    /repos/{owner}/{repo}/issues/{index}/comments: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "List all comments on an issue"
+        operationId: "issueGetComments"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "if provided, only comments updated since the specified time are returned."
+            name: "since"
+            in: "query"
+        responses: 
+          200: 
+            $ref: "#/responses/CommentList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Add a comment to an issue"
+        operationId: "issueCreateComment"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateIssueCommentOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Comment"
+    /repos/{owner}/{repo}/issues/{index}/comments/{id}: 
+      delete: 
+        tags: 
+          - "issue"
+        summary: "Delete a comment"
+        operationId: "issueDeleteCommentDeprecated"
+        deprecated: true
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "this parameter is ignored"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of comment to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Edit a comment"
+        operationId: "issueEditCommentDeprecated"
+        deprecated: true
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "this parameter is ignored"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the comment to edit"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditIssueCommentOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Comment"
+    /repos/{owner}/{repo}/issues/{index}/deadline: 
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Set an issue deadline. If set to null, the deadline is deleted."
+        operationId: "issueEditIssueDeadline"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue to create or update a deadline on"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditDeadlineOption"
+        responses: 
+          201: 
+            $ref: "#/responses/IssueDeadline"
+          403: 
+            description: "Not repo writer"
+            schema: 
+              $ref: "#/responses/forbidden"
+          404: 
+            description: "Issue not found"
+            schema: 
+              $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/issues/{index}/labels: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Get an issue's labels"
+        operationId: "issueGetLabels"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "index"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/LabelList"
+          404: 
+            $ref: "#/responses/notFound"
+      put: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Replace an issue's labels"
+        operationId: "issueReplaceLabels"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/IssueLabelsOption"
+        responses: 
+          200: 
+            $ref: "#/responses/LabelList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Add a label to an issue"
+        operationId: "issueAddLabel"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/IssueLabelsOption"
+        responses: 
+          200: 
+            $ref: "#/responses/LabelList"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Remove all labels from an issue"
+        operationId: "issueClearLabels"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "index"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/issues/{index}/labels/{id}: 
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Remove a label from an issue"
+        operationId: "issueRemoveLabel"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the issue"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the label to remove"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/keys: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repository's keys"
+        operationId: "repoListKeys"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/DeployKeyList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Add a key to a repository"
+        operationId: "repoCreateKey"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateKeyOption"
+        responses: 
+          201: 
+            $ref: "#/responses/DeployKey"
+    /repos/{owner}/{repo}/keys/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a repository's key by id"
+        operationId: "repoGetKey"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the key to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/DeployKey"
+      delete: 
+        tags: 
+          - "repository"
+        summary: "Delete a key from a repository"
+        operationId: "repoDeleteKey"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the key to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/labels: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Get all of a repository's labels"
+        operationId: "issueListLabels"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/LabelList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Create a label"
+        operationId: "issueCreateLabel"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateLabelOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Label"
+    /repos/{owner}/{repo}/labels/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Get a single label"
+        operationId: "issueGetLabel"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the label to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Label"
+      delete: 
+        tags: 
+          - "issue"
+        summary: "Delete a label"
+        operationId: "issueDeleteLabel"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the label to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Update a label"
+        operationId: "issueEditLabel"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the label to edit"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditLabelOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Label"
+    /repos/{owner}/{repo}/milestones: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Get all of a repository's milestones"
+        operationId: "issueGetMilestonesList"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/MilestoneList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Create a milestone"
+        operationId: "issueCreateMilestone"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateMilestoneOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Milestone"
+    /repos/{owner}/{repo}/milestones/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Get a milestone"
+        operationId: "issueGetMilestone"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the milestone"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Milestone"
+      delete: 
+        tags: 
+          - "issue"
+        summary: "Delete a milestone"
+        operationId: "issueDeleteMilestone"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the milestone to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "issue"
+        summary: "Update a milestone"
+        operationId: "issueEditMilestone"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the milestone"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditMilestoneOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Milestone"
+    /repos/{owner}/{repo}/mirror-sync: 
+      post: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Sync a mirrored repository"
+        operationId: "repoMirrorSync"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo to sync"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo to sync"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/pulls: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repo's pull requests"
+        operationId: "repoListPullRequests"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/PullRequestList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Create a pull request"
+        operationId: "repoCreatePullRequest"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreatePullRequestOption"
+        responses: 
+          201: 
+            $ref: "#/responses/PullRequest"
+    /repos/{owner}/{repo}/pulls/{index}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a pull request"
+        operationId: "repoGetPullRequest"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the pull request to get"
+            name: "index"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/PullRequest"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Update a pull request"
+        operationId: "repoEditPullRequest"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the pull request to edit"
+            name: "index"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditPullRequestOption"
+        responses: 
+          201: 
+            $ref: "#/responses/PullRequest"
+    /repos/{owner}/{repo}/pulls/{index}/merge: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Check if a pull request has been merged"
+        operationId: "repoPullRequestIsMerged"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the pull request"
+            name: "index"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            description: "pull request has been merged"
+            schema: 
+              $ref: "#/responses/empty"
+          404: 
+            description: "pull request has not been merged"
+            schema: 
+              $ref: "#/responses/empty"
+      post: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Merge a pull request"
+        operationId: "repoMergePullRequest"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "index of the pull request to merge"
+            name: "index"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/empty"
+          405: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/raw/{filepath}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a file from a repository"
+        operationId: "repoGetRawFile"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "filepath of the file to get"
+            name: "filepath"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            description: "success"
+    /repos/{owner}/{repo}/releases: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repo's releases"
+        operationId: "repoListReleases"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/ReleaseList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Create a release"
+        operationId: "repoCreateRelease"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateReleaseOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Release"
+    /repos/{owner}/{repo}/releases/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a release"
+        operationId: "repoGetRelease"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Release"
+      delete: 
+        tags: 
+          - "repository"
+        summary: "Delete a release"
+        operationId: "repoDeleteRelease"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Update a release"
+        operationId: "repoEditRelease"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release to edit"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditReleaseOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Release"
+    /repos/{owner}/{repo}/releases/{id}/assets: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List release's attachments"
+        operationId: "repoListReleaseAttachments"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/AttachmentList"
+      post: 
+        consumes: 
+          - "multipart/form-data"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Create a release attachment"
+        operationId: "repoCreateReleaseAttachment"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the attachment"
+            name: "name"
+            in: "query"
+          - 
+            type: "file"
+            description: "attachment to upload"
+            name: "attachment"
+            in: "formData"
+            required: true
+        responses: 
+          201: 
+            $ref: "#/responses/Attachment"
+    /repos/{owner}/{repo}/releases/{id}/assets/{attachment_id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a release attachment"
+        operationId: "repoGetReleaseAttachment"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the attachment to get"
+            name: "attachment_id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Attachment"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Delete a release attachment"
+        operationId: "repoDeleteReleaseAttachment"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the attachment to delete"
+            name: "attachment_id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Edit a release attachment"
+        operationId: "repoEditReleaseAttachment"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the release"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "id of the attachment to edit"
+            name: "attachment_id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditAttachmentOptions"
+        responses: 
+          201: 
+            $ref: "#/responses/Attachment"
+    /repos/{owner}/{repo}/stargazers: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repo's stargazers"
+        operationId: "repoListStargazers"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /repos/{owner}/{repo}/statuses/{sha}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a commit's statuses"
+        operationId: "repoListStatuses"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "sha of the commit"
+            name: "sha"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/StatusList"
+      post: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Create a commit status"
+        operationId: "repoCreateStatus"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "sha of the commit"
+            name: "sha"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateStatusOption"
+        responses: 
+          200: 
+            $ref: "#/responses/StatusList"
+    /repos/{owner}/{repo}/subscribers: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repo's watchers"
+        operationId: "repoListSubscribers"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /repos/{owner}/{repo}/subscription: 
+      get: 
+        tags: 
+          - "repository"
+        summary: "Check if the current user is watching a repo"
+        operationId: "userCurrentCheckSubscription"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/WatchInfo"
+      put: 
+        tags: 
+          - "repository"
+        summary: "Watch a repo"
+        operationId: "userCurrentPutSubscription"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/WatchInfo"
+      delete: 
+        tags: 
+          - "repository"
+        summary: "Unwatch a repo"
+        operationId: "userCurrentDeleteSubscription"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /repos/{owner}/{repo}/times: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "List a repo's tracked times"
+        operationId: "repoTrackedTimes"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/TrackedTimeList"
+    /repos/{owner}/{repo}/times/{user}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List a user's tracked times in a repo"
+        operationId: "userTrackedTimes"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of user"
+            name: "user"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/TrackedTimeList"
+    /repositories/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "Get a repository by id"
+        operationId: "repoGetByID"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the repo to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Repository"
+    /teams/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Get a team"
+        operationId: "orgGetTeam"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Team"
+      delete: 
+        tags: 
+          - "organization"
+        summary: "Delete a team"
+        operationId: "orgDeleteTeam"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            description: "team deleted"
+            schema: 
+              $ref: "#/responses/empty"
+      patch: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Edit a team"
+        operationId: "orgEditTeam"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team to edit"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/EditTeamOption"
+        responses: 
+          200: 
+            $ref: "#/responses/Team"
+    /teams/{id}/members: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List a team's members"
+        operationId: "orgListTeamMembers"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /teams/{id}/members/{username}: 
+      put: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Add a team member"
+        operationId: "orgAddTeamMember"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the user to add"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Remove a team member"
+        operationId: "orgRemoveTeamMember"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of the user to remove"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /teams/{id}/repos: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List a team's repos"
+        operationId: "orgListTeamRepos"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+    /teams/{id}/repos/{org}/{repo}: 
+      put: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Add a repository to a team"
+        operationId: "orgAddTeamRepository"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "organization that owns the repo to add"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo to add"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      delete: 
+        description: "This does not delete the repository, it only removes the repository from the team."
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "Remove a repository from a team"
+        operationId: "orgRemoveTeamRepository"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of the team"
+            name: "id"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "organization that owns the repo to remove"
+            name: "org"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo to remove"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /topics/search: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+        summary: "search topics via keyword"
+        operationId: "topicSearch"
+        parameters: 
+          - 
+            type: "string"
+            description: "keywords to search"
+            name: "q"
+            in: "query"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/Repository"
+    /user: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Get the authenticated user"
+        operationId: "userGetCurrent"
+        responses: 
+          200: 
+            $ref: "#/responses/User"
+    /user/emails: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the authenticated user's email addresses"
+        operationId: "userListEmails"
+        responses: 
+          200: 
+            $ref: "#/responses/EmailList"
+      post: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Add email addresses"
+        operationId: "userAddEmail"
+        parameters: 
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateEmailOption"
+        responses: 
+          201: 
+            $ref: "#/responses/EmailList"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Delete email addresses"
+        operationId: "userDeleteEmail"
+        parameters: 
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/DeleteEmailOption"
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /user/followers: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the authenticated user's followers"
+        operationId: "userCurrentListFollowers"
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /user/following: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the users that the authenticated user is following"
+        operationId: "userCurrentListFollowing"
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /user/following/{username}: 
+      get: 
+        tags: 
+          - "user"
+        summary: "Check whether a user is followed by the authenticated user"
+        operationId: "userCurrentCheckFollowing"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of followed user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          404: 
+            $ref: "#/responses/notFound"
+      put: 
+        tags: 
+          - "user"
+        summary: "Follow a user"
+        operationId: "userCurrentPutFollow"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user to follow"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      delete: 
+        tags: 
+          - "user"
+        summary: "Unfollow a user"
+        operationId: "userCurrentDeleteFollow"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user to unfollow"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /user/gpg_keys: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the authenticated user's GPG keys"
+        operationId: "userCurrentListGPGKeys"
+        responses: 
+          200: 
+            $ref: "#/responses/GPGKeyList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Create a GPG key"
+        operationId: "userCurrentPostGPGKey"
+        parameters: 
+          - 
+            name: "Form"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateGPGKeyOption"
+        responses: 
+          201: 
+            $ref: "#/responses/GPGKey"
+          422: 
+            $ref: "#/responses/validationError"
+    /user/gpg_keys/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Get a GPG key"
+        operationId: "userCurrentGetGPGKey"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of key to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/GPGKey"
+          404: 
+            $ref: "#/responses/notFound"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Remove a GPG key"
+        operationId: "userCurrentDeleteGPGKey"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of key to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          403: 
+            $ref: "#/responses/forbidden"
+    /user/keys: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the authenticated user's public keys"
+        operationId: "userCurrentListKeys"
+        responses: 
+          200: 
+            $ref: "#/responses/PublicKeyList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Create a public key"
+        operationId: "userCurrentPostKey"
+        parameters: 
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateKeyOption"
+        responses: 
+          201: 
+            $ref: "#/responses/PublicKey"
+          422: 
+            $ref: "#/responses/validationError"
+    /user/keys/{id}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Get a public key"
+        operationId: "userCurrentGetKey"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of key to get"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/PublicKey"
+          404: 
+            $ref: "#/responses/notFound"
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Delete a public key"
+        operationId: "userCurrentDeleteKey"
+        parameters: 
+          - 
+            type: "integer"
+            description: "id of key to delete"
+            name: "id"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          403: 
+            $ref: "#/responses/forbidden"
+          404: 
+            $ref: "#/responses/notFound"
+    /user/orgs: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List the current user's organizations"
+        operationId: "orgListCurrentUserOrgs"
+        responses: 
+          200: 
+            $ref: "#/responses/OrganizationList"
+    /user/repos: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the repos that the authenticated user owns or has access to"
+        operationId: "userCurrentListRepos"
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "repository"
+          - "user"
+        summary: "Create a repository"
+        operationId: "createCurrentUserRepo"
+        parameters: 
+          - 
+            name: "body"
+            in: "body"
+            schema: 
+              $ref: "#/definitions/CreateRepoOption"
+        responses: 
+          201: 
+            $ref: "#/responses/Repository"
+    /user/starred: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "The repos that the authenticated user has starred"
+        operationId: "userCurrentListStarred"
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+    /user/starred/{owner}/{repo}: 
+      get: 
+        tags: 
+          - "user"
+        summary: "Whether the authenticated is starring the repo"
+        operationId: "userCurrentCheckStarring"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          404: 
+            $ref: "#/responses/notFound"
+      put: 
+        tags: 
+          - "user"
+        summary: "Star the given repo"
+        operationId: "userCurrentPutStar"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo to star"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo to star"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+      delete: 
+        tags: 
+          - "user"
+        summary: "Unstar the given repo"
+        operationId: "userCurrentDeleteStar"
+        parameters: 
+          - 
+            type: "string"
+            description: "owner of the repo to unstar"
+            name: "owner"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "name of the repo to unstar"
+            name: "repo"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /user/subscriptions: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List repositories watched by the authenticated user"
+        operationId: "userCurrentListSubscriptions"
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+    /user/times: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the current user's tracked times"
+        operationId: "userCurrentTrackedTimes"
+        responses: 
+          200: 
+            $ref: "#/responses/TrackedTimeList"
+    /user/{username}/orgs: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "organization"
+        summary: "List a user's organizations"
+        operationId: "orgListUserOrgs"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/OrganizationList"
+    /users/search: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Search for users"
+        operationId: "userSearch"
+        parameters: 
+          - 
+            type: "string"
+            description: "keyword"
+            name: "q"
+            in: "query"
+          - 
+            type: "integer"
+            description: "maximum number of users to return"
+            name: "limit"
+            in: "query"
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /users/{follower}/following/{followee}: 
+      get: 
+        tags: 
+          - "user"
+        summary: "Check if one user is following another user"
+        operationId: "userCheckFollowing"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of following user"
+            name: "follower"
+            in: "path"
+            required: true
+          - 
+            type: "string"
+            description: "username of followed user"
+            name: "followee"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+          404: 
+            $ref: "#/responses/notFound"
+    /users/{username}: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Get a user"
+        operationId: "userGet"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user to get"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/User"
+          404: 
+            $ref: "#/responses/notFound"
+    /users/{username}/followers: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the given user's followers"
+        operationId: "userListFollowers"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /users/{username}/following: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the users that the given user is following"
+        operationId: "userListFollowing"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/UserList"
+    /users/{username}/gpg_keys: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the given user's GPG keys"
+        operationId: "userListGPGKeys"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/GPGKeyList"
+    /users/{username}/keys: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the given user's public keys"
+        operationId: "userListKeys"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/PublicKeyList"
+    /users/{username}/repos: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the repos owned by the given user"
+        operationId: "userListRepos"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+    /users/{username}/starred: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "The repos that the given user has starred"
+        operationId: "userListStarred"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+    /users/{username}/subscriptions: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the repositories watched by a user"
+        operationId: "userListSubscriptions"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of the user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/RepositoryList"
+    /users/{username}/tokens: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "List the authenticated user's access tokens"
+        operationId: "userGetTokens"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/AccessTokenList"
+      post: 
+        consumes: 
+          - "application/json"
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "Create an access token"
+        operationId: "userCreateToken"
+        parameters: 
+          - 
+            type: "string"
+            x-go-name: "Name"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+        responses: 
+          200: 
+            $ref: "#/responses/AccessToken"
+    /users/{username}/tokens/{token}: 
+      delete: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "user"
+        summary: "delete an access token"
+        operationId: "userDeleteAccessToken"
+        parameters: 
+          - 
+            type: "string"
+            description: "username of user"
+            name: "username"
+            in: "path"
+            required: true
+          - 
+            type: "integer"
+            description: "token to be deleted"
+            name: "token"
+            in: "path"
+            required: true
+        responses: 
+          204: 
+            $ref: "#/responses/empty"
+    /version: 
+      get: 
+        produces: 
+          - "application/json"
+        tags: 
+          - "miscellaneous"
+        summary: "Returns the version of the Gitea application"
+        operationId: "getVersion"
+        responses: 
+          200: 
+            $ref: "#/responses/ServerVersion"
+  definitions: 
+    AddCollaboratorOption: 
+      description: "AddCollaboratorOption options when adding a user as a collaborator of a repository"
+      type: "object"
+      properties: 
+        permission: 
+          type: "string"
+          x-go-name: "Permission"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    AddTimeOption: 
+      description: "AddTimeOption options for adding time to an issue"
+      type: "object"
+      required: 
+        - "time"
+      properties: 
+        time: 
+          description: "time in seconds"
+          type: "integer"
+          format: "int64"
+          x-go-name: "Time"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Attachment: 
+      description: "Attachment a generic attachment"
+      type: "object"
+      properties: 
+        browser_download_url: 
+          type: "string"
+          x-go-name: "DownloadURL"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        download_count: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "DownloadCount"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+        size: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Size"
+        uuid: 
+          type: "string"
+          x-go-name: "UUID"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Branch: 
+      description: "Branch represents a repository branch"
+      type: "object"
+      properties: 
+        commit: 
+          $ref: "#/definitions/PayloadCommit"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Comment: 
+      description: "Comment represents a comment on a commit or issue"
+      type: "object"
+      properties: 
+        body: 
+          type: "string"
+          x-go-name: "Body"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        html_url: 
+          type: "string"
+          x-go-name: "HTMLURL"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        issue_url: 
+          type: "string"
+          x-go-name: "IssueURL"
+        pull_request_url: 
+          type: "string"
+          x-go-name: "PRURL"
+        updated_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Updated"
+        user: 
+          $ref: "#/definitions/User"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateEmailOption: 
+      description: "CreateEmailOption options when creating email addresses"
+      type: "object"
+      properties: 
+        emails: 
+          description: "email addresses to add"
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Emails"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateForkOption: 
+      description: "CreateForkOption options for creating a fork"
+      type: "object"
+      properties: 
+        organization: 
+          description: "organization name, if forking into an organization"
+          type: "string"
+          x-go-name: "Organization"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateGPGKeyOption: 
+      description: "CreateGPGKeyOption options create user GPG key"
+      type: "object"
+      required: 
+        - "armored_public_key"
+      properties: 
+        armored_public_key: 
+          description: "An armored GPG key to add"
+          type: "string"
+          uniqueItems: true
+          x-go-name: "ArmoredKey"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateHookOption: 
+      description: "CreateHookOption options when create a hook"
+      type: "object"
+      required: 
+        - "type"
+        - "config"
+      properties: 
+        active: 
+          type: "boolean"
+          default: false
+          x-go-name: "Active"
+        config: 
+          type: "object"
+          additionalProperties: 
+            type: "string"
+          x-go-name: "Config"
+        events: 
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Events"
+        type: 
+          type: "string"
+          enum: 
+            - "gitea"
+            - "gogs"
+            - "slack"
+            - "discord"
+          x-go-name: "Type"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateIssueCommentOption: 
+      description: "CreateIssueCommentOption options for creating a comment on an issue"
+      type: "object"
+      required: 
+        - "body"
+      properties: 
+        body: 
+          type: "string"
+          x-go-name: "Body"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateIssueOption: 
+      description: "CreateIssueOption options to create one issue"
+      type: "object"
+      required: 
+        - "title"
+      properties: 
+        assignee: 
+          description: "username of assignee"
+          type: "string"
+          x-go-name: "Assignee"
+        assignees: 
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Assignees"
+        body: 
+          type: "string"
+          x-go-name: "Body"
+        closed: 
+          type: "boolean"
+          x-go-name: "Closed"
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        labels: 
+          description: "list of label ids"
+          type: "array"
+          items: 
+            type: "integer"
+            format: "int64"
+          x-go-name: "Labels"
+        milestone: 
+          description: "milestone id"
+          type: "integer"
+          format: "int64"
+          x-go-name: "Milestone"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateKeyOption: 
+      description: "CreateKeyOption options when creating a key"
+      type: "object"
+      required: 
+        - "title"
+        - "key"
+      properties: 
+        key: 
+          description: "An armored SSH key to add"
+          type: "string"
+          uniqueItems: true
+          x-go-name: "Key"
+        read_only: 
+          description: "Describe if the key has only read access or read/write"
+          type: "boolean"
+          x-go-name: "ReadOnly"
+        title: 
+          description: "Title of the key to add"
+          type: "string"
+          uniqueItems: true
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateLabelOption: 
+      description: "CreateLabelOption options for creating a label"
+      type: "object"
+      required: 
+        - "name"
+        - "color"
+      properties: 
+        color: 
+          type: "string"
+          x-go-name: "Color"
+          example: "#00aabb"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateMilestoneOption: 
+      description: "CreateMilestoneOption options for creating a milestone"
+      type: "object"
+      properties: 
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        due_on: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateOrgOption: 
+      description: "CreateOrgOption options for creating an organization"
+      type: "object"
+      required: 
+        - "username"
+      properties: 
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        full_name: 
+          type: "string"
+          x-go-name: "FullName"
+        location: 
+          type: "string"
+          x-go-name: "Location"
+        username: 
+          type: "string"
+          x-go-name: "UserName"
+        website: 
+          type: "string"
+          x-go-name: "Website"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreatePullRequestOption: 
+      description: "CreatePullRequestOption options when creating a pull request"
+      type: "object"
+      properties: 
+        assignee: 
+          type: "string"
+          x-go-name: "Assignee"
+        assignees: 
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Assignees"
+        base: 
+          type: "string"
+          x-go-name: "Base"
+        body: 
+          type: "string"
+          x-go-name: "Body"
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        head: 
+          type: "string"
+          x-go-name: "Head"
+        labels: 
+          type: "array"
+          items: 
+            type: "integer"
+            format: "int64"
+          x-go-name: "Labels"
+        milestone: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Milestone"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateReleaseOption: 
+      description: "CreateReleaseOption options when creating a release"
+      type: "object"
+      required: 
+        - "tag_name"
+      properties: 
+        body: 
+          type: "string"
+          x-go-name: "Note"
+        draft: 
+          type: "boolean"
+          x-go-name: "IsDraft"
+        name: 
+          type: "string"
+          x-go-name: "Title"
+        prerelease: 
+          type: "boolean"
+          x-go-name: "IsPrerelease"
+        tag_name: 
+          type: "string"
+          x-go-name: "TagName"
+        target_commitish: 
+          type: "string"
+          x-go-name: "Target"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateRepoOption: 
+      description: "CreateRepoOption options when creating repository"
+      type: "object"
+      required: 
+        - "name"
+      properties: 
+        auto_init: 
+          description: "Whether the repository should be auto-intialized?"
+          type: "boolean"
+          x-go-name: "AutoInit"
+        description: 
+          description: "Description of the repository to create"
+          type: "string"
+          x-go-name: "Description"
+        gitignores: 
+          description: "Gitignores to use"
+          type: "string"
+          x-go-name: "Gitignores"
+        license: 
+          description: "License to use"
+          type: "string"
+          x-go-name: "License"
+        name: 
+          description: "Name of the repository to create"
+          type: "string"
+          uniqueItems: true
+          x-go-name: "Name"
+        private: 
+          description: "Whether the repository is private"
+          type: "boolean"
+          x-go-name: "Private"
+        readme: 
+          description: "Readme of the repository to create"
+          type: "string"
+          x-go-name: "Readme"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateStatusOption: 
+      description: "CreateStatusOption holds the information needed to create a new Status for a Commit"
+      type: "object"
+      properties: 
+        context: 
+          type: "string"
+          x-go-name: "Context"
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        state: 
+          $ref: "#/definitions/StatusState"
+        target_url: 
+          type: "string"
+          x-go-name: "TargetURL"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateTeamOption: 
+      description: "CreateTeamOption options for creating a team"
+      type: "object"
+      required: 
+        - "name"
+      properties: 
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+        permission: 
+          type: "string"
+          enum: 
+            - "read"
+            - "write"
+            - "admin"
+          x-go-name: "Permission"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    CreateUserOption: 
+      description: "CreateUserOption create user options"
+      type: "object"
+      required: 
+        - "username"
+        - "email"
+        - "password"
+      properties: 
+        email: 
+          type: "string"
+          format: "email"
+          x-go-name: "Email"
+        full_name: 
+          type: "string"
+          x-go-name: "FullName"
+        login_name: 
+          type: "string"
+          x-go-name: "LoginName"
+        password: 
+          type: "string"
+          x-go-name: "Password"
+        send_notify: 
+          type: "boolean"
+          x-go-name: "SendNotify"
+        source_id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "SourceID"
+        username: 
+          type: "string"
+          x-go-name: "Username"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    DeleteEmailOption: 
+      description: "DeleteEmailOption options when deleting email addresses"
+      type: "object"
+      properties: 
+        emails: 
+          description: "email addresses to delete"
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Emails"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    DeployKey: 
+      description: "DeployKey a deploy key"
+      type: "object"
+      properties: 
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        key: 
+          type: "string"
+          x-go-name: "Key"
+        read_only: 
+          type: "boolean"
+          x-go-name: "ReadOnly"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditAttachmentOptions: 
+      description: "EditAttachmentOptions options for editing attachments"
+      type: "object"
+      properties: 
+        name: 
+          type: "string"
+          x-go-name: "Name"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditDeadlineOption: 
+      description: "EditDeadlineOption options for creating a deadline"
+      type: "object"
+      required: 
+        - "due_date"
+      properties: 
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditHookOption: 
+      description: "EditHookOption options when modify one hook"
+      type: "object"
+      properties: 
+        active: 
+          type: "boolean"
+          x-go-name: "Active"
+        config: 
+          type: "object"
+          additionalProperties: 
+            type: "string"
+          x-go-name: "Config"
+        events: 
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Events"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditIssueCommentOption: 
+      description: "EditIssueCommentOption options for editing a comment"
+      type: "object"
+      required: 
+        - "body"
+      properties: 
+        body: 
+          type: "string"
+          x-go-name: "Body"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditIssueOption: 
+      description: "EditIssueOption options for editing an issue"
+      type: "object"
+      properties: 
+        assignee: 
+          type: "string"
+          x-go-name: "Assignee"
+        assignees: 
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Assignees"
+        body: 
+          type: "string"
+          x-go-name: "Body"
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        milestone: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Milestone"
+        state: 
+          type: "string"
+          x-go-name: "State"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditLabelOption: 
+      description: "EditLabelOption options for editing a label"
+      type: "object"
+      properties: 
+        color: 
+          type: "string"
+          x-go-name: "Color"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditMilestoneOption: 
+      description: "EditMilestoneOption options for editing a milestone"
+      type: "object"
+      properties: 
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        due_on: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        state: 
+          type: "string"
+          x-go-name: "State"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditOrgOption: 
+      description: "EditOrgOption options for editing an organization"
+      type: "object"
+      properties: 
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        full_name: 
+          type: "string"
+          x-go-name: "FullName"
+        location: 
+          type: "string"
+          x-go-name: "Location"
+        website: 
+          type: "string"
+          x-go-name: "Website"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditPullRequestOption: 
+      description: "EditPullRequestOption options when modify pull request"
+      type: "object"
+      properties: 
+        assignee: 
+          type: "string"
+          x-go-name: "Assignee"
+        assignees: 
+          type: "array"
+          items: 
+            type: "string"
+          x-go-name: "Assignees"
+        body: 
+          type: "string"
+          x-go-name: "Body"
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        labels: 
+          type: "array"
+          items: 
+            type: "integer"
+            format: "int64"
+          x-go-name: "Labels"
+        milestone: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Milestone"
+        state: 
+          type: "string"
+          x-go-name: "State"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditReleaseOption: 
+      description: "EditReleaseOption options when editing a release"
+      type: "object"
+      properties: 
+        body: 
+          type: "string"
+          x-go-name: "Note"
+        draft: 
+          type: "boolean"
+          x-go-name: "IsDraft"
+        name: 
+          type: "string"
+          x-go-name: "Title"
+        prerelease: 
+          type: "boolean"
+          x-go-name: "IsPrerelease"
+        tag_name: 
+          type: "string"
+          x-go-name: "TagName"
+        target_commitish: 
+          type: "string"
+          x-go-name: "Target"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditTeamOption: 
+      description: "EditTeamOption options for editing a team"
+      type: "object"
+      required: 
+        - "name"
+      properties: 
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+        permission: 
+          type: "string"
+          enum: 
+            - "read"
+            - "write"
+            - "admin"
+          x-go-name: "Permission"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    EditUserOption: 
+      description: "EditUserOption edit user options"
+      type: "object"
+      required: 
+        - "email"
+      properties: 
+        active: 
+          type: "boolean"
+          x-go-name: "Active"
+        admin: 
+          type: "boolean"
+          x-go-name: "Admin"
+        allow_git_hook: 
+          type: "boolean"
+          x-go-name: "AllowGitHook"
+        allow_import_local: 
+          type: "boolean"
+          x-go-name: "AllowImportLocal"
+        email: 
+          type: "string"
+          format: "email"
+          x-go-name: "Email"
+        full_name: 
+          type: "string"
+          x-go-name: "FullName"
+        location: 
+          type: "string"
+          x-go-name: "Location"
+        login_name: 
+          type: "string"
+          x-go-name: "LoginName"
+        max_repo_creation: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "MaxRepoCreation"
+        password: 
+          type: "string"
+          x-go-name: "Password"
+        source_id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "SourceID"
+        website: 
+          type: "string"
+          x-go-name: "Website"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Email: 
+      description: "Email an email address belonging to a user"
+      type: "object"
+      properties: 
+        email: 
+          type: "string"
+          format: "email"
+          x-go-name: "Email"
+        primary: 
+          type: "boolean"
+          x-go-name: "Primary"
+        verified: 
+          type: "boolean"
+          x-go-name: "Verified"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    GPGKey: 
+      description: "GPGKey a user GPG key to sign commit and tag in repository"
+      type: "object"
+      properties: 
+        can_certify: 
+          type: "boolean"
+          x-go-name: "CanCertify"
+        can_encrypt_comms: 
+          type: "boolean"
+          x-go-name: "CanEncryptComms"
+        can_encrypt_storage: 
+          type: "boolean"
+          x-go-name: "CanEncryptStorage"
+        can_sign: 
+          type: "boolean"
+          x-go-name: "CanSign"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        emails: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/GPGKeyEmail"
+          x-go-name: "Emails"
+        expires_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Expires"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        key_id: 
+          type: "string"
+          x-go-name: "KeyID"
+        primary_key_id: 
+          type: "string"
+          x-go-name: "PrimaryKeyID"
+        public_key: 
+          type: "string"
+          x-go-name: "PublicKey"
+        subkeys: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/GPGKey"
+          x-go-name: "SubsKey"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    GPGKeyEmail: 
+      description: "GPGKeyEmail an email attached to a GPGKey"
+      type: "object"
+      properties: 
+        email: 
+          type: "string"
+          x-go-name: "Email"
+        verified: 
+          type: "boolean"
+          x-go-name: "Verified"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Issue: 
+      description: "Issue represents an issue in a repository"
+      type: "object"
+      properties: 
+        assignee: 
+          $ref: "#/definitions/User"
+        assignees: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/User"
+          x-go-name: "Assignees"
+        body: 
+          type: "string"
+          x-go-name: "Body"
+        closed_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Closed"
+        comments: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Comments"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        labels: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/Label"
+          x-go-name: "Labels"
+        milestone: 
+          $ref: "#/definitions/Milestone"
+        number: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Index"
+        pull_request: 
+          $ref: "#/definitions/PullRequestMeta"
+        state: 
+          $ref: "#/definitions/StateType"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+        updated_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Updated"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+        user: 
+          $ref: "#/definitions/User"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    IssueDeadline: 
+      description: "IssueDeadline represents an issue deadline"
+      type: "object"
+      properties: 
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    IssueLabelsOption: 
+      description: "IssueLabelsOption a collection of labels"
+      type: "object"
+      properties: 
+        labels: 
+          description: "list of label IDs"
+          type: "array"
+          items: 
+            type: "integer"
+            format: "int64"
+          x-go-name: "Labels"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Label: 
+      description: "Label a label to an issue or a pr"
+      type: "object"
+      properties: 
+        color: 
+          type: "string"
+          x-go-name: "Color"
+          example: "00aabb"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    MarkdownOption: 
+      description: "MarkdownOption markdown options"
+      type: "object"
+      properties: 
+        Context: 
+          description: "Context to render\n\nin: body"
+          type: "string"
+        Mode: 
+          description: "Mode to render\n\nin: body"
+          type: "string"
+        Text: 
+          description: "Text markdown to render\n\nin: body"
+          type: "string"
+        Wiki: 
+          description: "Is it a wiki page ?\n\nin: body"
+          type: "boolean"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    MigrateRepoForm: 
+      description: "MigrateRepoForm form for migrating repository"
+      type: "object"
+      required: 
+        - "clone_addr"
+        - "uid"
+        - "repo_name"
+      properties: 
+        auth_password: 
+          type: "string"
+          x-go-name: "AuthPassword"
+        auth_username: 
+          type: "string"
+          x-go-name: "AuthUsername"
+        clone_addr: 
+          type: "string"
+          x-go-name: "CloneAddr"
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        mirror: 
+          type: "boolean"
+          x-go-name: "Mirror"
+        private: 
+          type: "boolean"
+          x-go-name: "Private"
+        repo_name: 
+          type: "string"
+          x-go-name: "RepoName"
+        uid: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "UID"
+      x-go-package: "code.gitea.io/gitea/modules/auth"
+    Milestone: 
+      description: "Milestone milestone is a collection of issues on one repository"
+      type: "object"
+      properties: 
+        closed_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Closed"
+        closed_issues: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ClosedIssues"
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        due_on: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        open_issues: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "OpenIssues"
+        state: 
+          $ref: "#/definitions/StateType"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Organization: 
+      description: "Organization represents an organization"
+      type: "object"
+      properties: 
+        avatar_url: 
+          type: "string"
+          x-go-name: "AvatarURL"
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        full_name: 
+          type: "string"
+          x-go-name: "FullName"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        location: 
+          type: "string"
+          x-go-name: "Location"
+        username: 
+          type: "string"
+          x-go-name: "UserName"
+        website: 
+          type: "string"
+          x-go-name: "Website"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    PRBranchInfo: 
+      description: "PRBranchInfo information about a branch"
+      type: "object"
+      properties: 
+        label: 
+          type: "string"
+          x-go-name: "Name"
+        ref: 
+          type: "string"
+          x-go-name: "Ref"
+        repo: 
+          $ref: "#/definitions/Repository"
+        repo_id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "RepoID"
+        sha: 
+          type: "string"
+          x-go-name: "Sha"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    PayloadCommit: 
+      description: "PayloadCommit represents a commit"
+      type: "object"
+      properties: 
+        author: 
+          $ref: "#/definitions/PayloadUser"
+        committer: 
+          $ref: "#/definitions/PayloadUser"
+        id: 
+          description: "sha1 hash of the commit"
+          type: "string"
+          x-go-name: "ID"
+        message: 
+          type: "string"
+          x-go-name: "Message"
+        timestamp: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Timestamp"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+        verification: 
+          $ref: "#/definitions/PayloadCommitVerification"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    PayloadCommitVerification: 
+      description: "PayloadCommitVerification represents the GPG verification of a commit"
+      type: "object"
+      properties: 
+        payload: 
+          type: "string"
+          x-go-name: "Payload"
+        reason: 
+          type: "string"
+          x-go-name: "Reason"
+        signature: 
+          type: "string"
+          x-go-name: "Signature"
+        verified: 
+          type: "boolean"
+          x-go-name: "Verified"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    PayloadUser: 
+      description: "PayloadUser represents the author or committer of a commit"
+      type: "object"
+      properties: 
+        email: 
+          type: "string"
+          format: "email"
+          x-go-name: "Email"
+        name: 
+          description: "Full name of the commit author"
+          type: "string"
+          x-go-name: "Name"
+        username: 
+          type: "string"
+          x-go-name: "UserName"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Permission: 
+      description: "Permission represents a set of permissions"
+      type: "object"
+      properties: 
+        admin: 
+          type: "boolean"
+          x-go-name: "Admin"
+        pull: 
+          type: "boolean"
+          x-go-name: "Pull"
+        push: 
+          type: "boolean"
+          x-go-name: "Push"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    PublicKey: 
+      description: "PublicKey publickey is a user key to push code to repository"
+      type: "object"
+      properties: 
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        fingerprint: 
+          type: "string"
+          x-go-name: "Fingerprint"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        key: 
+          type: "string"
+          x-go-name: "Key"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    PullRequest: 
+      description: "PullRequest represents a pull request"
+      type: "object"
+      properties: 
+        assignee: 
+          $ref: "#/definitions/User"
+        assignees: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/User"
+          x-go-name: "Assignees"
+        base: 
+          $ref: "#/definitions/PRBranchInfo"
+        body: 
+          type: "string"
+          x-go-name: "Body"
+        closed_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Closed"
+        comments: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Comments"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        diff_url: 
+          type: "string"
+          x-go-name: "DiffURL"
+        due_date: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Deadline"
+        head: 
+          $ref: "#/definitions/PRBranchInfo"
+        html_url: 
+          type: "string"
+          x-go-name: "HTMLURL"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        labels: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/Label"
+          x-go-name: "Labels"
+        merge_base: 
+          type: "string"
+          x-go-name: "MergeBase"
+        merge_commit_sha: 
+          type: "string"
+          x-go-name: "MergedCommitID"
+        mergeable: 
+          type: "boolean"
+          x-go-name: "Mergeable"
+        merged: 
+          type: "boolean"
+          x-go-name: "HasMerged"
+        merged_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Merged"
+        merged_by: 
+          $ref: "#/definitions/User"
+        milestone: 
+          $ref: "#/definitions/Milestone"
+        number: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Index"
+        patch_url: 
+          type: "string"
+          x-go-name: "PatchURL"
+        state: 
+          $ref: "#/definitions/StateType"
+        title: 
+          type: "string"
+          x-go-name: "Title"
+        updated_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Updated"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+        user: 
+          $ref: "#/definitions/User"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    PullRequestMeta: 
+      description: "PullRequestMeta PR info if an issue is a PR"
+      type: "object"
+      properties: 
+        merged: 
+          type: "boolean"
+          x-go-name: "HasMerged"
+        merged_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Merged"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Release: 
+      description: "Release represents a repository release"
+      type: "object"
+      properties: 
+        assets: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/Attachment"
+          x-go-name: "Attachments"
+        author: 
+          $ref: "#/definitions/User"
+        body: 
+          type: "string"
+          x-go-name: "Note"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "CreatedAt"
+        draft: 
+          type: "boolean"
+          x-go-name: "IsDraft"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        name: 
+          type: "string"
+          x-go-name: "Title"
+        prerelease: 
+          type: "boolean"
+          x-go-name: "IsPrerelease"
+        published_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "PublishedAt"
+        tag_name: 
+          type: "string"
+          x-go-name: "TagName"
+        tarball_url: 
+          type: "string"
+          x-go-name: "TarURL"
+        target_commitish: 
+          type: "string"
+          x-go-name: "Target"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+        zipball_url: 
+          type: "string"
+          x-go-name: "ZipURL"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Repository: 
+      description: "Repository represents a repository"
+      type: "object"
+      properties: 
+        clone_url: 
+          type: "string"
+          x-go-name: "CloneURL"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        default_branch: 
+          type: "string"
+          x-go-name: "DefaultBranch"
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        empty: 
+          type: "boolean"
+          x-go-name: "Empty"
+        fork: 
+          type: "boolean"
+          x-go-name: "Fork"
+        forks_count: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Forks"
+        full_name: 
+          type: "string"
+          x-go-name: "FullName"
+        html_url: 
+          type: "string"
+          x-go-name: "HTMLURL"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        mirror: 
+          type: "boolean"
+          x-go-name: "Mirror"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+        open_issues_count: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "OpenIssues"
+        owner: 
+          $ref: "#/definitions/User"
+        parent: 
+          $ref: "#/definitions/Repository"
+        permissions: 
+          $ref: "#/definitions/Permission"
+        private: 
+          type: "boolean"
+          x-go-name: "Private"
+        size: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Size"
+        ssh_url: 
+          type: "string"
+          x-go-name: "SSHURL"
+        stars_count: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Stars"
+        updated_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Updated"
+        watchers_count: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "Watchers"
+        website: 
+          type: "string"
+          x-go-name: "Website"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    SearchResults: 
+      description: "SearchResults results of a successful search"
+      type: "object"
+      properties: 
+        data: 
+          type: "array"
+          items: 
+            $ref: "#/definitions/Repository"
+          x-go-name: "Data"
+        ok: 
+          type: "boolean"
+          x-go-name: "OK"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    ServerVersion: 
+      description: "ServerVersion wraps the version of the server"
+      type: "object"
+      properties: 
+        version: 
+          type: "string"
+          x-go-name: "Version"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    StateType: 
+      description: "StateType issue state type"
+      type: "string"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Status: 
+      description: "Status holds a single Status of a single Commit"
+      type: "object"
+      properties: 
+        context: 
+          type: "string"
+          x-go-name: "Context"
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        creator: 
+          $ref: "#/definitions/User"
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        status: 
+          $ref: "#/definitions/StatusState"
+        target_url: 
+          type: "string"
+          x-go-name: "TargetURL"
+        updated_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Updated"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    StatusState: 
+      description: "StatusState holds the state of a Status\nIt can be \"pending\", \"success\", \"error\", \"failure\", and \"warning\""
+      type: "string"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    Team: 
+      description: "Team represents a team in an organization"
+      type: "object"
+      properties: 
+        description: 
+          type: "string"
+          x-go-name: "Description"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        name: 
+          type: "string"
+          x-go-name: "Name"
+        permission: 
+          type: "string"
+          enum: 
+            - "none"
+            - "read"
+            - "write"
+            - "admin"
+            - "owner"
+          x-go-name: "Permission"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    TrackedTime: 
+      description: "TrackedTime worked time for an issue / pr"
+      type: "object"
+      properties: 
+        created: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "Created"
+        id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        issue_id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "IssueID"
+        time: 
+          description: "Time in seconds"
+          type: "integer"
+          format: "int64"
+          x-go-name: "Time"
+        user_id: 
+          type: "integer"
+          format: "int64"
+          x-go-name: "UserID"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    User: 
+      description: "User represents a user"
+      type: "object"
+      properties: 
+        avatar_url: 
+          description: "URL to the user's avatar"
+          type: "string"
+          x-go-name: "AvatarURL"
+        email: 
+          type: "string"
+          format: "email"
+          x-go-name: "Email"
+        full_name: 
+          description: "the user's full name"
+          type: "string"
+          x-go-name: "FullName"
+        id: 
+          description: "the user's id"
+          type: "integer"
+          format: "int64"
+          x-go-name: "ID"
+        language: 
+          description: "User locale"
+          type: "string"
+          x-go-name: "Language"
+        login: 
+          description: "the user's username"
+          type: "string"
+          x-go-name: "UserName"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+    WatchInfo: 
+      description: "WatchInfo represents an API watch status of one repository"
+      type: "object"
+      properties: 
+        created_at: 
+          type: "string"
+          format: "date-time"
+          x-go-name: "CreatedAt"
+        ignored: 
+          type: "boolean"
+          x-go-name: "Ignored"
+        reason: 
+          type: "object"
+          x-go-name: "Reason"
+        repository_url: 
+          type: "string"
+          x-go-name: "RepositoryURL"
+        subscribed: 
+          type: "boolean"
+          x-go-name: "Subscribed"
+        url: 
+          type: "string"
+          x-go-name: "URL"
+      x-go-package: "code.gitea.io/gitea/vendor/code.gitea.io/sdk/gitea"
+  responses: 
+    AccessToken: 
+      description: "AccessToken represents a API access token."
+      headers: 
+        id: 
+          type: "integer"
+          format: "int64"
+        name: 
+          type: "string"
+        sha1: 
+          type: "string"
+    AccessTokenList: 
+      description: "AccessTokenList represents a list of API access token."
+    Attachment: 
+      description: "Attachment"
+      schema: 
+        $ref: "#/definitions/Attachment"
+    AttachmentList: 
+      description: "AttachmentList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Attachment"
+    Branch: 
+      description: "Branch"
+      schema: 
+        $ref: "#/definitions/Branch"
+    BranchList: 
+      description: "BranchList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Branch"
+    Comment: 
+      description: "Comment"
+      schema: 
+        $ref: "#/definitions/Comment"
+    CommentList: 
+      description: "CommentList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Comment"
+    DeployKey: 
+      description: "DeployKey"
+      schema: 
+        $ref: "#/definitions/DeployKey"
+    DeployKeyList: 
+      description: "DeployKeyList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/DeployKey"
+    EmailList: 
+      description: "EmailList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Email"
+    GPGKey: 
+      description: "GPGKey"
+      schema: 
+        $ref: "#/definitions/GPGKey"
+    GPGKeyList: 
+      description: "GPGKeyList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/GPGKey"
+    Hook: 
+      description: "Hook"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Branch"
+    HookList: 
+      description: "HookList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Branch"
+    Issue: 
+      description: "Issue"
+      schema: 
+        $ref: "#/definitions/Issue"
+    IssueDeadline: 
+      description: "IssueDeadline"
+      schema: 
+        $ref: "#/definitions/IssueDeadline"
+    IssueList: 
+      description: "IssueList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Issue"
+    Label: 
+      description: "Label"
+      schema: 
+        $ref: "#/definitions/Label"
+    LabelList: 
+      description: "LabelList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Label"
+    MarkdownRender: 
+      description: "MarkdownRender is a rendered markdown document"
+    Milestone: 
+      description: "Milestone"
+      schema: 
+        $ref: "#/definitions/Milestone"
+    MilestoneList: 
+      description: "MilestoneList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Milestone"
+    Organization: 
+      description: "Organization"
+      schema: 
+        $ref: "#/definitions/Organization"
+    OrganizationList: 
+      description: "OrganizationList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Organization"
+    PublicKey: 
+      description: "PublicKey"
+      schema: 
+        $ref: "#/definitions/PublicKey"
+    PublicKeyList: 
+      description: "PublicKeyList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/PublicKey"
+    PullRequest: 
+      description: "PullRequest"
+      schema: 
+        $ref: "#/definitions/PullRequest"
+    PullRequestList: 
+      description: "PullRequestList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/PullRequest"
+    Release: 
+      description: "Release"
+      schema: 
+        $ref: "#/definitions/Release"
+    ReleaseList: 
+      description: "ReleaseList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Release"
+    Repository: 
+      description: "Repository"
+      schema: 
+        $ref: "#/definitions/Repository"
+    RepositoryList: 
+      description: "RepositoryList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Repository"
+    SearchResults: 
+      description: "SearchResults"
+      schema: 
+        $ref: "#/definitions/SearchResults"
+    ServerVersion: 
+      description: "ServerVersion"
+      schema: 
+        $ref: "#/definitions/ServerVersion"
+    Status: 
+      description: "Status"
+      schema: 
+        $ref: "#/definitions/Status"
+    StatusList: 
+      description: "StatusList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Status"
+    Team: 
+      description: "Team"
+      schema: 
+        $ref: "#/definitions/Team"
+    TeamList: 
+      description: "TeamList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/Team"
+    TrackedTime: 
+      description: "TrackedTime"
+      schema: 
+        $ref: "#/definitions/TrackedTime"
+    TrackedTimeList: 
+      description: "TrackedTimeList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/TrackedTime"
+    User: 
+      description: "User"
+      schema: 
+        $ref: "#/definitions/User"
+    UserList: 
+      description: "UserList"
+      schema: 
+        type: "array"
+        items: 
+          $ref: "#/definitions/User"
+    WatchInfo: 
+      description: "WatchInfo"
+      schema: 
+        $ref: "#/definitions/WatchInfo"
+    empty: 
+      description: "APIEmpty is an empty response"
+    error: 
+      description: "APIError is error format response"
+      headers: 
+        message: 
+          type: "string"
+        url: 
+          type: "string"
+    forbidden: 
+      description: "APIForbiddenError is a forbidden error response"
+      headers: 
+        message: 
+          type: "string"
+        url: 
+          type: "string"
+    notFound: 
+      description: "APINotFound is a not found empty response"
+    parameterBodies: 
+      description: "parameterBodies"
+      schema: 
+        $ref: "#/definitions/EditAttachmentOptions"
+    redirect: 
+      description: "APIRedirect is a redirect response"
+    validationError: 
+      description: "APIValidationError is error format response related to input validation"
+      headers: 
+        message: 
+          type: "string"
+        url: 
+          type: "string"
+  securityDefinitions: 
+    AccessToken: 
+      type: "apiKey"
+      name: "access_token"
+      in: "query"
+    AuthorizationHeaderToken: 
+      type: "apiKey"
+      name: "Authorization"
+      in: "header"
+    BasicAuth: 
+      type: "basic"
+    Token: 
+      type: "apiKey"
+      name: "token"
+      in: "query"
+  security: 
+    - 
+      BasicAuth: []
+    - 
+      Token: []
+    - 
+      AccessToken: []
+    - 
+      AuthorizationHeaderToken: []
+

--- a/fixtures/bugs/1621/definitions.yaml
+++ b/fixtures/bugs/1621/definitions.yaml
@@ -1,0 +1,618 @@
+definitions:
+
+  # Generic response model
+  V4GenericResponse:
+    type: object
+    properties:
+      message:
+        type: string
+        description: A human readable message
+      code:
+        type: string
+        description: |
+          A machine readable [response code](https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md) like e. g. `INVALID_CREDENTIALS`
+
+  # Info resposne
+  V4InfoResponse:
+    type: object
+    properties:
+      general:
+        description: General information
+        type: object
+        properties:
+          installation_name:
+            description: Unique name of the installation
+            type: string
+          provider:
+            description: The technical provider used in this installation. Either "kvm", "aws", or "azure".
+            type: string
+          datacenter:
+            description: Identifier of the datacenter or cloud provider region, e. g. "eu-west-1"
+            type: string
+      workers:
+        description: Information related to worker nodes
+        type: object
+        properties:
+          count_per_cluster:
+            description: Number of workers per cluster
+            type: object
+            properties:
+              max:
+                description: Maximum number of worker a cluster can have
+                type: number
+              default:
+                description: Default number of workers in a new cluster will have, if not specifiec otherwise
+                type: number
+          instance_type:
+            description: Instance types to be used for worker nodes. Only available for AWS clusters.
+            type: object
+            properties:
+              options:
+                description: List of available instance types
+                type: array
+                items:
+                  type: string
+              default:
+                description: The instance type used in new cluster, if not specified
+                type: string
+          vm_size:
+            description: Azure Virtual Machine size to be used for worker nodes. Only available for Azure clusters.
+            type: object
+            properties:
+              options:
+                description: List of available instance types
+                type: array
+                items:
+                  type: string
+              default:
+                description: The instance type used in new cluster, if not specified
+                type: string
+
+  # Request to create a new cluster
+  V4AddClusterRequest:
+    type: object
+    required:
+      - owner
+    description: Request model for creating a new cluster
+    properties:
+      owner:
+        type: string
+        description: Name of the organization owning the cluster
+      name:
+        type: string
+        description: Cluster name
+      release_version:
+        type: string
+        description: |
+          The [release](https://docs.giantswarm.io/api/#tag/releases) version
+          to use in the new cluster
+      kubernetes_version:
+        type: string
+        description: |
+          Kubernetes version number (deprecated). Doesn't have any effect.
+          This attribute is going to be removed in future API versions.
+      workers:
+        type: array
+        items:
+          $ref: '#/definitions/V4NodeDefinition'
+
+  V4ModifyClusterRequest:
+    type: object
+    required: []
+    description: Request body for cluster modification
+    properties:
+      name:
+        type: string
+        description: Name for the cluster
+      owner:
+        type: string
+        description: Name of the organization owning the cluster
+      release_version:
+        type: string
+        description: Release version to use after an upgrade
+      workers:
+        type: array
+        description: Worker node array
+        items:
+          $ref: '#/definitions/V4NodeDefinition'
+
+  # Details on existing cluster
+  V4ClusterDetailsResponse:
+    type: object
+    description: Response model showing details of a cluster
+    properties:
+      id:
+        type: string
+        description: Unique cluster identifier
+      api_endpoint:
+        type: string
+        description: URI of the Kubernetes API endpoint
+      create_date:
+        type: string
+        description: Date/time of cluster creation
+      owner:
+        type: string
+        description: Name of the organization owning the cluster
+      name:
+        type: string
+        description: Cluster name
+      release_version:
+        type: string
+        description: |
+          The [release](https://docs.giantswarm.io/api/#tag/releases) version
+          currently running this cluster.
+      kubernetes_version:
+        type: string
+        description: Deprecated. Will be removed in a future API version.
+      workers:
+        type: array
+        items:
+          $ref: '#/definitions/V4NodeDefinition'
+      kvm:
+        type: object
+        description: Attributes specific to clusters running on KVM (on-prem) installations.
+        properties:
+          port_mappings:
+            type: array
+            description: |
+              Reveals the ports on the host cluster that are mapped to this guest cluster's ingress
+              and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters.
+            items:
+              type: object
+              properties:
+                port:
+                  description: |
+                    The port on the host cluster that will forward traffic to the guest cluster
+                  type: integer
+                protocol:
+                  description: |
+                    The protocol this port mapping is made for.
+                  type: string
+
+  # Definition of a cluster node
+  V4NodeDefinition:
+    type: object
+    properties:
+      aws:
+        type: object
+        description: |
+          Attributes specific to nodes running on Amazon Web Services (AWS)
+        properties:
+          instance_type:
+            type: string
+            description: |
+              EC2 instance type name. Must be the same for all worker nodes
+              of a cluster.
+      azure:
+        type: object
+        description: |
+          Attributes specific to nodes running on Microsoft Azure
+        properties:
+          vm_size:
+            type: string
+            description: |
+              Azure Virtual Machine size. Must be the same for all worker nodes
+              of a cluster.
+      memory:
+        type: object
+        properties:
+          size_gb:
+            type: number
+            description: RAM size in GB. Can be an integer or float.
+      storage:
+        type: object
+        properties:
+          size_gb:
+            type: number
+            description: Node storage size in GB. Can be an integer or float.
+      cpu:
+        type: object
+        properties:
+          cores:
+            type: integer
+            description: Number of CPU cores
+      labels:
+        type: object
+        additionalProperties: true
+
+  # List of key pairs
+  V4GetKeyPairsResponse:
+    type: array
+    description: Array of sparse key pair objects
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the key pair
+        description:
+          type: string
+          description: Free text information about the key pair
+        ttl_hours:
+          type: integer
+          description: Expiration time (from creation) in hours
+        create_date:
+          type: string
+          description: Date/time of creation
+        common_name:
+          type: string
+          description: The common name of the certificate subject.
+        certificate_organizations:
+          type: string
+          description: The certificate subject's `organization` fields.
+
+  # Add key pair request
+  V4AddKeyPairRequest:
+    type: object
+    required:
+      - description
+    properties:
+      description:
+        type: string
+        description: Free text information about the key pair
+      ttl_hours:
+        type: integer
+        format: int32
+        description: Expiration time (from creation) in hours
+      cn_prefix:
+        type: string
+        description: The common name prefix of the certificate subject. This only allows characters that are usable in domain names (`a-z`, `0-9`, and `.-`, where `.-` must not occur at either the start or the end).
+      certificate_organizations:
+        type: string
+        description: |
+          This will set the certificate subject's `organization` fields.
+          Use a comma seperated list of values.
+
+  V4AddKeyPairResponse:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique identifier of the key pair
+      description:
+        type: string
+        description: Free text information about the key pair
+      ttl_hours:
+        type: integer
+        description: Expiration time (from creation) in hours
+      create_date:
+        type: string
+        description: Date/time of creation
+      certificate_authority_data:
+        type: string
+        description: PEM-encoded CA certificate of the cluster
+      client_key_data:
+        type: string
+        description: PEM-encoded RSA private key
+      client_certificate_data:
+        type: string
+        description: PEM-encoded certificate
+
+  # cluster metrics
+  V4GetClusterMetricsResponse:
+    description: Response for the getClusterMetrics operation
+    type: object
+    properties:
+      workers:
+        description: Group of metrics regarding workers
+        type: array
+        items:
+          $ref: '#/definitions/V4NodeMetrics'
+
+  V4NodeMetrics:
+    type: object
+    properties:
+      id:
+        description: String identifying the node
+        type: string
+      metrics:
+        description: Container object for all metrics available for the node
+        type: object
+        properties:
+          container_count:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          pod_count:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          cpu_used:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          ram_free:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          ram_available:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          ram_cached:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          ram_buffers:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          ram_mapped:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          node_storage_used:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          network_rx:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          network_tx:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          resource_cpu_requests:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          resource_cpu_limits:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          resource_ram_requests:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+          resource_ram_limits:
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
+
+  # a complete organization object
+  V4Organization:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique name/identifier of the organization
+      members:
+        type: array
+        description: List of members that belong to this organization
+        items:
+          $ref: '#/definitions/V4OrganizationMember'
+
+  # An organization as returned by getOrganizations as an array item
+  V4OrganizationListItem:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique name/identifier of the organization
+
+  # A user that belongs to an organization
+  V4OrganizationMember:
+    type: object
+    properties:
+      email:
+        type: string
+        description: Email address of the user
+
+  # One of the users in the array as returned by getUsers
+  V4UserListItem:
+    type: object
+    properties:
+      email:
+        type: string
+        description: Email address of the user
+      created:
+        type: string
+        description: The date and time that this account was created
+      expiry:
+        type: string
+        description: The date and time when this account will expire
+
+  # A cluster array item, as return by getClusters
+  V4ClusterListItem:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique cluster identifier
+      create_date:
+        type: string
+        description: Date/time of cluster creation
+      name:
+        type: string
+        description: Cluster name
+      owner:
+        type: string
+        description: Name of the organization owning the cluster
+      release_version:
+        type: string
+        description: The semantic version number of this cluster
+
+  # A cluster array item, as return by getClusters
+  V4ReleaseListItem:
+    type: object
+    required: ["version", "timestamp", "changelog", "components"]
+    properties:
+      version:
+        type: string
+        description: The semantic version number
+      timestamp:
+        type: string
+        description: Date and time of the release creation
+      active:
+        type: boolean
+        description: |
+          If true, the version is available for new clusters and cluster
+          upgrades. Older versions become unavailable and thus have the
+          value `false` here.
+      changelog:
+        description: |
+          Structured list of changes in this release, in comparison to the
+          previous version, with respect to the contained components.
+        type: array
+        items:
+          type: object
+          properties:
+            component:
+              type: string
+              description: |
+                If the changed item was a component, this attribute is the
+                name of the component.
+            description:
+              type: string
+              description: Human-friendly description of the change
+      components:
+        description: |
+          List of components and their version contained in the release
+        type: array
+        items:
+          type: object
+          required: ["name", "version"]
+          properties:
+            name:
+              type: string
+              description: Name of the component
+            version:
+              type: string
+              description: Version number of the component
+
+  V4CreateUserRequest:
+    type: object
+    required:
+      - password
+    description: Request model for creating a new user
+    properties:
+      password:
+        type: string
+        description: A Base64 encoded password
+      expiry:
+        type: string
+        description: The date and time when this account will expire
+
+  V4AddCredentialsRequest:
+    type: object
+    required:
+      - provider
+    description: Request model for adding a set of credentials
+    properties:
+      provider:
+        type: string
+      aws:
+        type: object
+        description: Credentials specific to an AWS account
+        required:
+          - roles
+        properties:
+          roles:
+            type: object
+            descriptions: IAM roles to assume by certain entities
+            required:
+              - awsoperator
+              - admin
+            properties:
+              admin:
+                type: string
+                description: ARN of the IAM role to assume by Giant Swarm support staff
+              awsoperator:
+                type: string
+                description: ARN of the IAM role to assume by the software operating clusters
+
+  # A request for an auth token
+  V4CreateAuthTokenRequest:
+    type: object
+    properties:
+      email:
+        type: string
+        description: Your email address
+      password_base64:
+        type: string
+        description: Your password as a base64 encoded string
+
+  # A response to a successful auth token request
+  V4CreateAuthTokenResponse:
+    type: object
+    properties:
+      auth_token:
+        type: string
+        description: The newly created API token
+

--- a/fixtures/bugs/1621/fixture-1621.yaml
+++ b/fixtures/bugs/1621/fixture-1621.yaml
@@ -1,0 +1,1325 @@
+swagger: "2.0"
+info:
+  title: The Giant Swarm API v4
+  description: |
+    This is the documentation for the Giant Swarm API starting at version `v4`.
+
+    For an introduction to Giant Swarm, refer to the [documentation site](https://docs.giantswarm.io/).
+
+    The Giant Swarm API attempts to behave in a __restful__ way. As a developer, you access resources using the `GET` method and, for example, delete them using the same path and the `DELETE` method.
+
+    Accessing resources via GET usually returns all information available about a resource, while collections, like for example the list of all clusters you have access to, only contain a selected few attributes of each member item.
+
+    Some requests, like for example the request to create a new cluster, don't return the resource itself. Instead, the response delivers a standard message body, showing a `code` and a `message` part. The `message` contains information for you or a client's end user. The `code` attribute contains some string (example: `RESOURCE_CREATED`) that is supposed to give you details on the state of the operation, in addition to standard HTTP status codes. This message format is also used in the case of errors. We provide a [list of all response codes](https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md) outside this documentation.
+
+    Feedback on the API as well as this documentation is welcome via `support@giantswarm.io` or on IRC channel [#giantswarm](irc://irc.freenode.org:6667/#giantswarm) on freenode.
+
+    ## Source
+
+    The source of this documentation is available on [GitHub](https://github.com/giantswarm/api-spec).
+
+  termsOfService: https://giantswarm.io/terms/
+  version: 4.0.0
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+consumes:
+  - application/json
+produces:
+  - application/json
+tags:
+  - name: auth tokens
+    description: |
+      Auth Tokens are your way of authenticating against this API. You can create one by passing your email and base64 encoded password to the create auth token endpoint. The auth token never expires, in case you want to invalidate it you need to delete it (logout).
+  - name: clusters
+    description: |
+      Clusters are a central resource of the Giant Swarm API. As a user or team using Giant Swarm, you set up Kubernetes clusters to run your own workloads.
+
+      The API currently provides operations to create and delete clusters, as well as list all available clusters and get details on specific clusters.
+  - name: info
+    description: Information about the Giant Swarm installation
+  - name: key pairs
+    description: A key pair is a unique combination of a X.509 certificate and a private key. Key pairs are used to access the Kubernetes API of a cluster, both using `kubectl` and any standard web browser.
+    externalDocs:
+      url: https://docs.giantswarm.io/guides/accessing-services-from-the-outside/
+      description: "User guide: Accessing Pods and Services from the Outside"
+  - name: organizations
+    description: Organizations are groups of users who own resources like clusters.
+  - name: users
+    description: A user represents a person that should have access to the Giant Swarm API. Users can belong to many groups, and are identified by email address.
+  - name: releases
+    description: |
+      A release is a software bundle that constitutes a cluster.
+
+      Releases are identified by their
+      [semantic version number](http://semver.org/) in the `MAJOR.MINOR.PATCH`
+      format.
+
+      A release provides _components_, like for example Kubernetes. For each
+      release the contained components are listed. Changes in components are
+      detailed in the _changelog_ of a release.
+securityDefinitions:
+  AuthorizationHeaderToken:
+    description: |
+      Clients authenticate by passing an auth token via the `Authorization`
+      header with a value of the format `giantswarm <token>`. Auth tokens can be
+      obtained using the [createAuthToken](#operation/createAuthToken)
+      operation.
+    type: apiKey
+    name: Authorization
+    in: header
+
+security:
+  - AuthorizationHeaderToken: []
+
+paths:
+  /v4/info/:
+    get:
+      operationId: getInfo
+      tags:
+        - info
+      summary: Get information on the installation
+      description: |
+        Returns a set of details on the installation. The output varies based
+        on the provider used in the installation.
+
+        This information is useful for example when creating new cluster, to
+        prevent creating clusters with more worker nodes than possible.
+
+        ### Example for an AWS-based installation
+
+        ```json
+        {
+          "general": {
+            "installation_name": "shire",
+            "provider": "aws",
+            "datacenter": "eu-central-1"
+          },
+          "workers": {
+            "count_per_cluster": {
+              "max": 20,
+              "default": 3
+            },
+            "instance_type": {
+              "options": [
+                "m3.medium", "m3.large", "m3.xlarge"
+              ],
+              "default": "m3.large"
+            }
+          }
+        }
+        ```
+
+        ### Example for a KVM-based installation
+
+        ```json
+        {
+          "general": {
+            "installation_name": "isengard",
+            "provider": "kvm",
+            "datacenter": "string"
+          },
+          "workers": {
+            "count_per_cluster": {
+              "max": 8,
+              "default": 3
+            },
+          }
+        }
+        ```
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Information
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4InfoResponse"
+          examples:
+            application/json:
+              {
+                "general": {
+                  "installation_name": "shire",
+                  "provider": "aws",
+                  "datacenter": "eu-central-1"
+                },
+                "workers": {
+                  "count_per_cluster": {
+                    "max": 20,
+                    "default": 3
+                  },
+                  "instance_type": {
+                    "options": [
+                      "m3.medium", "m3.large", "m3.xlarge"
+                    ],
+                    "default": "m3.large"
+                  }
+                }
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/auth-tokens/:
+    post:
+      operationId: createAuthToken
+      tags:
+        - auth tokens
+      summary: Create Auth Token (Login)
+      description: |
+        Creates a Auth Token for a given user. Must authenticate with email and password.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - name: body
+          in: body
+          required: true
+          description: Create Auth Token Request
+          schema:
+            $ref: 'definitions.yaml#/definitions/V4CreateAuthTokenRequest'
+          x-examples:
+            application/json:
+              {
+                "email": "developer@example.com",
+                "password_base64": "cGFzc3dvcmQ="
+              }
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateAuthTokenResponse"
+          examples:
+            application/json:
+              {
+                "auth_token": "e5239484-2299-41df-b901-d0568db7e3f9"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+
+    delete:
+      operationId: deleteAuthToken
+      tags:
+        - auth tokens
+      summary: Delete Auth Token (Logout)
+      description: |
+        Deletes the authentication token provided in the Authorization header. This effectively logs you out.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETED",
+                "message": "The authentication token has been succesfully deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+
+  /v4/users/:
+    get:
+      operationId: getUsers
+      tags:
+        - users
+      summary: Get users
+      description: |
+        Returns a list of all users in the system. Currently this endpoint is only available to users with admin permissions.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: "./definitions.yaml#/definitions/V4UserListItem"
+          examples:
+            application/json:
+              [
+                {"email": "andy@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2019-01-15T00:00:00Z"},
+                {"email": "bob@example.com", "created": "2017-02-15T12:30:00Z", "expiry": "2020-01-15T00:00:00Z"},
+                {"email": "charles@example.com", "created": "2017-03-15T13:00:00Z", "expiry": "2021-01-15T00:00:00Z"}
+              ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/user/:
+    get:
+      operationId: getCurrentUser
+      tags:
+        - users
+      summary: Get current user
+      description: |
+        Returns details about the currently authenticated user
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4UserListItem"
+          examples:
+            application/json:
+             {"email": "andy@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2019-01-15T00:00:00Z"}
+        "201":
+          # Fake response added with expanded content of 200, to run test assertion, e.g. 200 <=> 201
+          description: Success
+          schema:
+            type: object
+            properties:
+              email:
+                type: string
+                description: Email address of the user
+              created:
+                type: string
+                description: The date and time that this account was created
+              expiry:
+                type: string
+                description: The date and time when this account will expire
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/users/{email}/:
+    get:
+      operationId: getUser
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/UserEmailPathParameter"
+      tags:
+        - users
+      summary: Get user
+      description: |
+        Returns details about a specific user
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4UserListItem"
+          examples:
+            application/json:
+              {"email": "andy@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2019-01-15T00:00:00Z"}
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: User not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The user could not be found. (not found: user with email 'bob@example.com' could not be found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    put:
+      operationId: createUser
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/UserEmailPathParameter"
+        - name: body
+          in: body
+          required: true
+          description: User account details
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateUserRequest"
+          x-examples:
+            application/json:
+              {
+                "password": "cGFzc3dvcmQ=",
+                "expiry": "2020-01-01T12:00:00.000Z"
+              }
+      tags:
+        - users
+      summary: Create user
+      description: |
+        Creates a users in the system. Currently this endpoint is only available to users with admin permissions.
+      responses:
+        "201":
+          description: User created
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "The user with email 'bob@example.com' has been created."
+              }
+        "400":
+          description: User already exists
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "The user could not be created. (invalid input: email 'bob@example.com' already exists)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    delete:
+      operationId: deleteUser
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/UserEmailPathParameter"
+      tags:
+        - users
+      summary: Delete user
+      description: |
+        Deletes a users in the system. Currently this endpoint is only available
+        to users with admin permissions.
+      responses:
+        "200":
+          description: User deleted
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETED",
+                "message": "The user with email 'bob@example.com' has been deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: User not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The user could not be deleted. (not found: user with email 'bob@example.com' could not be found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/clusters/:
+    get:
+      operationId: getClusters
+      tags:
+        - clusters
+      summary: Get clusters
+      description: |
+        This operation fetches a list of clusters.
+
+        The result depends on the permissions of the user.
+        A normal user will get all the clusters the user has access
+        to, via organization membership.
+        A user with admin permission will receive a list of all existing
+        clusters.
+
+        The result array items are sparse representations of the cluster objects.
+        To fetch more details on a cluster, use the [getCluster](#operation/getCluster)
+        operation.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: "./definitions.yaml#/definitions/V4ClusterListItem"
+          examples:
+            application/json:
+              [
+                {
+                  "id": "g8s3o",
+                  "create_date": "2017-06-08T12:31:47.215Z",
+                  "name": "Staging Cluster",
+                  "owner": "acme"
+                },
+                {
+                  "id": "3dkr6",
+                  "create_date": "2017-05-22T13:58:02.024Z",
+                  "name": "Test Cluster",
+                  "owner": "testorg"
+                }
+              ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    post:
+      operationId: addCluster
+      tags:
+        - clusters
+      summary: Create cluster
+      description: |
+        This operation is used to create a new Kubernetes cluster for an
+        organization. The desired configuration can be specified using the
+        __cluster definition format__ (see
+        [external documentation](https://github.com/giantswarm/api-spec/blob/master/details/CLUSTER_DEFINITION.md)
+        for details).
+
+        The cluster definition format allows to set a number of optional
+        configuration details, like memory size and number of CPU cores.
+        However, one attribute is __mandatory__ upon creation: The `owner`
+        attribute must carry the name of the organization the cluster will
+        belong to. Note that the acting user must be a member of that
+        organization in order to create a cluster.
+
+        It is *recommended* to also specify the `name` attribute to give the
+        cluster a friendly name, like e. g. "Development Cluster".
+
+        Additional definition attributes can be used. Where attributes are
+        omitted, default configuration values will be applied. For example, if
+        no `release_version` is specified, the most recent version is used.
+
+        The `workers` attribute, if present, must contain an array of node
+        definition objects. The number of objects given determines the number
+        of workers created.
+
+        For example, requesting three worker nodes with default configuration
+        can be achieved by submitting an array of three empty objects:
+
+        ```"workers": [{}, {}, {}]```
+
+        For clusters on AWS, note that all worker nodes must use the same instance type.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - name: body
+          in: body
+          required: true
+          description: New cluster definition
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4AddClusterRequest"
+          x-examples:
+            application/json:
+              {
+                "owner": "myteam",
+                "release_version": "1.4.2",
+                "name": "Example cluster with 3 default worker nodes",
+                "workers": [{}, {}, {}]
+              }
+      responses:
+        "201":
+          description: Cluster created
+          headers:
+            Location:
+              type: string
+              description: URI to obtain details on the new cluster using the [getCluster](#operation/getCluster) operation
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "A new cluster has been created with ID 'wqtlq'"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/clusters/{cluster_id}/:
+    get:
+      operationId: getCluster
+      tags:
+        - clusters
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+      summary: Get cluster details
+      description: |
+        This operation allows to obtain all available details on a particular cluster.
+      responses:
+        "200":
+          description: Cluster details
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4ClusterDetailsResponse"
+          examples:
+            application/json:
+              {
+                "id": "wqtlq",
+                "create_date": "2017-03-03T10:50:45.949270905Z",
+                "api_endpoint": "https://api.wqtlq.example.com",
+                "name": "Just a Standard Cluster",
+                "release_version": "2.5.16",
+                "kubernetes_version": "",
+                "owner": "acme",
+                "workers": [
+                  {
+                    "memory": {"size_gb": 2.0},
+                    "storage": {"size_gb": 20.0},
+                    "cpu": {"cores": 4},
+                    "labels": {
+                      "beta.kubernetes.io/arch": "amd64",
+                      "beta.kubernetes.io/os": "linux",
+                      "ip": "10.3.11.2",
+                      "kubernetes.io/hostname": "worker-1.x882ofna.k8s.gigantic.io",
+                      "nodetype": "hicpu"
+                    }
+                  },
+                  {
+                    "memory": {"size_gb": 8.0},
+                    "storage": {"size_gb": 20.0},
+                    "cpu": {"cores": 2},
+                    "labels": {
+                      "beta.kubernetes.io/arch": "amd64",
+                      "beta.kubernetes.io/os": "linux",
+                      "ip": "10.3.62.2",
+                      "kubernetes.io/hostname": "worker-2.x882ofna.k8s.gigantic.io",
+                      "nodetype": "hiram"
+                    }
+                  }
+                ],
+                "kvm": {
+                  "port_mappings": [
+                    {
+                      "port": 30020,
+                      "protocol": "http"
+                    },
+                    {
+                      "port": 30021,
+                      "protocol": "https"
+                    },
+                  ]
+                }
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Cluster not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    patch:
+      operationId: modifyCluster
+      tags:
+        - clusters
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - name: body
+          in: body
+          required: true
+          description: Merge-patch body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4ModifyClusterRequest"
+          x-examples:
+            application/merge-patch+json:
+              {
+                "name": "New cluster name"
+              }
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+      summary: Modify cluster
+      description: |
+        This operation allows to modify an existing cluster.
+
+        A cluster modification is performed by submitting a `PATCH` request
+        to the cluster resource (as described in the
+        [addCluster](#operation/addCluster) and [getCluster](#operation/getCluster))
+        in form of a [JSON Patch Merge
+        (RFC 7386)](https://tools.ietf.org/html/rfc7386). This means, only the
+        attributes to be modified have to be contained in the request body.
+
+        The following attributes can be modified:
+
+        - `name`: Rename the cluster to something more fitting.
+
+        - `owner`: Changing the owner organization name means to change cluster
+        ownership from one organization to another. The user performing the
+        request has to be a member of both organizations.
+
+        - `release_version`: By changing this attribute you can upgrade a
+        cluster to a newer
+        [release](https://docs.giantswarm.io/api/#tag/releases).
+
+        - `workers`: By modifying the array of workers, nodes can be added to
+        increase the cluster's capacity. See details below.
+
+        ### Adding and Removing Worker Nodes (Scaling)
+
+        Adding worker nodes to a cluster or removing worker nodes from a cluster
+        works by submitting the `workers` attribute, which contains a (sparse)
+        array of worker node defintions.
+
+        _Sparse_ here means that all configuration details are optional. In the
+        case that worker nodes are added to a cluster, wherever a configuration
+        detail is missing, defaults will be applied. See
+        [Creating a cluster](#operation/addCluster) for details.
+
+        When modifying the cluster resource, you describe the desired state.
+        For scaling, this means that the worker node array submitted must
+        contain as many elements as the cluster should have worker nodes.
+        If your cluster currently has five nodes and you submit a workers
+        array with four elements, this means that one worker node will be removed.
+        If your submitted workers array has six elements, this means one will
+        be added.
+
+        As an example, this request body could be used to scale a cluster to
+        three worker nodes:
+
+        ```json
+        {
+          "workers": [{}, {}, {}]
+        }
+        ```
+
+        If the scaled cluster had four worker nodes before, one would be removed.
+        If it had two worker nodes before, one with default settings would be
+        added.
+
+        ### Limitations
+
+        - As of now, existing worker nodes cannot be modified.
+        - When removing nodes (scaling down), it is not possible to determine
+        which nodes will be removed.
+        - On AWS based clusters, all worker nodes must use the same EC2 instance
+        type (`instance_type` node attribute). By not setting an `instance_type`
+        when submitting a PATCH request, you ensure that the right instance type
+        is used automatically.
+
+      responses:
+        "200":
+          description: Cluster modified
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4ClusterDetailsResponse"
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Cluster not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    delete:
+      operationId: deleteCluster
+      tags:
+        - clusters
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+      summary: Delete cluster
+      description: |
+        This operation allows to delete a cluster.
+
+        __Caution:__ Deleting a cluster causes the termination of all workloads running on the cluster. Data stored on the worker nodes will be lost. There is no way to undo this operation.
+
+        The response is sent as soon as the request is validated.
+        At that point, workloads might still be running on the cluster and may be accessible for a little wile, until the cluster is actually deleted.
+      responses:
+        "202":
+          description: Deleting cluster
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETION_STARTED",
+                "message": "The cluster with ID 'wqtlq' is being deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Cluster not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/clusters/{cluster_id}/key-pairs/:
+    get:
+      operationId: getKeyPairs
+      tags:
+        - key pairs
+      summary: Get key pairs
+      description: |
+        Returns a list of information on all key pairs of a cluster as an array.
+
+        The individual array items contain metadata on the key pairs, but neither the key nor the certificate. These can only be obtained upon creation, using the [addKeypair](#operation/addKeyPair) operation.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+      responses:
+        "200":
+          description: Key pairs
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetKeyPairsResponse"
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    post:
+      operationId: addKeyPair
+      tags:
+        - key pairs
+      summary: Create key pair
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - name: body
+          in: body
+          required: true
+          description: |
+            While the `ttl_hours` attribute is optional and will be set to a default value when omitted, the `description` is mandatory.
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4AddKeyPairRequest"
+          x-examples:
+            application/json:
+              {
+                "description": "Admin key pair lasting twelve hours",
+                "ttl_hours": 12,
+                "certificate_organizations": "system:masters"
+              }
+      description: |
+        This operation allows to create a new key pair for accessing a specific cluster.
+
+        A key pair consists of an unencrypted private RSA key and an X.509 certificate. In addition, when obtaining a key pair for a cluster, the cluster's certificate authority file (CA certificate) is delivered, which is required by TLS clients to establish trust to the cluster.
+
+        In addition to the credentials itself, a key pair has some metadata like a unique ID, a creation timestamp and a free text `description` that you can use at will, for example to note for whom a key pair has been issued.
+
+        ### Customizing the certificate's subject for K8s RBAC
+
+        It is possible to set the Common Name and Organization fields of the generated certificate's subject.
+
+        - `cn_prefix`: The certificate's common name uses this format: `<cn_prefix>.user.<clusterdomain>`.
+
+          `clusterdomain` is specific to your cluster and is not editable.
+
+          The `cn_prefix` however is editable. When left blank it will default
+          to the email address of the Giant Swarm user that is performing the
+          create key pair request.
+
+          The common name is used as the username for requests to the Kubernetes API. This allows you
+          to set up role-based access controls.
+
+
+        - `certificate_organizations`: This will set the certificate's `organization` fields. Use a comma separated list of values.
+          The Kubernetes API will use these values as group memberships.
+
+        __Note:__ The actual credentials coming with the key pair (key, certificate) can only be accessed once, as the result of the `POST` request that triggers their creation. This restriction exists to minimize the risk of credentials being leaked. If you fail to capture the credentials upon creation, you'll have to repeat the creation request.
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4AddKeyPairResponse"
+          examples:
+            application/json:
+              {
+                "certificate_authority_data": "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----",
+                "client_key_data": "-----BEGIN RSA PRIVATE KEY-----...-----END RSA PRIVATE KEY-----",
+                "client_certificate_data": "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----",
+                "create_date": "2016-06-01T12:00:00.000Z",
+                "description": "Key pair description",
+                "id": "02:cc:da:f9:fb:ce:c3:e5:e1:f6:27:d8:43:48:0d:37:4a:ee:b9:67",
+                "ttl_hours": 8640
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+
+  /v4/organizations/:
+    get:
+      operationId: getOrganizations
+      tags:
+        - organizations
+      summary: Get organizations
+      description: |
+        This operation allows to fetch a list of organizations the user is a
+        member of. In the case of an admin user, the result includes all
+        existing organizations.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: "./definitions.yaml#/definitions/V4OrganizationListItem"
+          examples:
+            application/json:
+              [
+                {"id": "acme"},
+                {"id": "giantswarm"},
+                {"id": "testorg"}
+              ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/organizations/{organization_id}/:
+    get:
+      operationId: getOrganization
+      tags:
+        - organizations
+      summary: Get organization details
+      description: |
+        This operation fetches organization details.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
+      responses:
+        "200":
+          description: Organization details
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4Organization"
+          examples:
+            application/json:
+              {
+                "id": "acme",
+                "members": [
+                  {"email": "user1@example.com"},
+                  {"email": "user2@example.com"}
+                ]
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Organization not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The organization could not be found. (not found: the organization with id 'acme' could not be found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    put:
+      operationId: addOrganization
+      tags:
+        - organizations
+      summary: Create an organization
+      description: |
+        This operation allows a user to create an organization.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4Organization"
+          x-examples:
+            application/json:
+              {
+                "id": "string",
+                "members": [
+                  {"email": "myself@example.com"},
+                  {"email": "colleague@example.com"}
+                ]
+              }
+      responses:
+        "201":
+          description: Organization created
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4Organization"
+          examples:
+            application/json:
+              {
+                "id": "acme",
+                "members": [
+                  {"email": "user1@example.com"},
+                  {"email": "user2@example.com"}
+                ]
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "409":
+          description: Organization already exists
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "The organization could not be created. (org already exists)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    patch:
+      operationId: modifyOrganization
+      tags:
+        - organizations
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              members:
+                type: array
+                description: List of members that belong to this organization
+                items:
+                  $ref: "./definitions.yaml#/definitions/V4OrganizationMember"
+          x-examples:
+            application/merge-patch+json:
+              {
+                "members": [{"email": "myself@example.com"}]
+              }
+
+      summary: Modify organization
+      description: |
+        This operation allows you to modify an existing organization. You must be
+        a member of the organization or an admin in order to use this endpoint.
+
+        The following attributes can be modified:
+
+        - `members`: By modifying the array of members, members can be added to or removed from the organization
+
+        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
+        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+
+        The full request must be valid before it will be executed, currently this
+        means every member you attempt to add to the organization must actually
+        exist in the system. If any member you attempt to add is invalid, the entire
+        patch operation will fail, no members will be added or removed, and an error message
+        will explain which members in your request are invalid.
+      responses:
+        "200":
+          description: Organization modified
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4Organization"
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "The organization could not be modified. (invalid input: user 'invalid-email' does not exist or is invalid)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Organization not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The organization could not be modified. (not found: the organization with id 'acme' could not be found)"
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    delete:
+      operationId: deleteOrganization
+      tags:
+        - organizations
+      summary: Delete an organization
+      description: |
+        This operation allows a user to delete an organization that they are a member of.
+        Admin users can delete any organization.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
+      responses:
+        "200":
+          description: Organization deleted
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETED",
+                "message": "The organization with ID 'acme' has been deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Organization not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The organization could not be deleted. (not found: the organization with id 'acme' could not be found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/organizations/{organization_id}/credentials/:
+    post:
+      operationId: addCredentials
+      tags:
+        - organizations
+      summary: Set credentials
+      description: |
+        Add a set of credentials to the organization allowing the creation and
+        operation of clusters within a cloud provider account/subscription.
+
+        The actual type of these credentials depends on the cloud provider the
+        installation is running on. Currently, only AWS is supported, with
+        support for Azure being planned for the near future.
+
+        Credentials in an organization are immutable. Each organization can only
+        have one set of credentials.
+
+        Once credentials have been set for an organization, they are used for
+        every new cluster that will be created for the organization.
+
+        ### Example request body for AWS
+
+        ```json
+        {
+          "provider": "aws",
+          "aws": {
+            "roles": {
+              "admin": "arn:aws:iam::123456789012:role/GiantSwarmAdmin",
+              "awsoperator": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
+            }
+          }
+        }
+        ```
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4AddCredentialsRequest"
+          x-examples:
+            application/json:
+              {
+                "provider": "aws",
+                "aws": {
+                  "roles": {
+                    "admin": "arn:aws:iam::123456789012:role/GiantSwarmAdmin",
+                    "awsoperator": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
+                  }
+                }
+              }
+      responses:
+        "201":
+          description: Credentials created
+          headers:
+            Location:
+              type: string
+              description: URI of the new credentials resource
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "A new set of credentials has been created with ID '5d9h4'"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "409":
+          description: Conflict
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "The organisation already has a set of credentials"
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/releases/:
+    get:
+      operationId: getReleases
+      tags:
+        - releases
+      summary: Get releases
+      description: |
+        Lists all releases available for new clusters or for upgrading existing
+        clusters. Might also serve as an archive to obtain details on older
+        releases.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Releases list
+          schema:
+            type: array
+            items:
+              $ref: "./definitions.yaml#/definitions/V4ReleaseListItem"
+          examples:
+            application/json:
+              [
+                {
+                  "version": "1.14.9",
+                  "timestamp": "2017-09-21T08:14:03.37759Z",
+                  "changelog": [
+                    {
+                      "component": "kubernetes",
+                      "description": "Security fixes"
+                    },
+                    {
+                      "component": "calico",
+                      "description": "Security fixes"
+                    }
+                  ],
+                  "components": [
+                    {
+                      "name": "kubernetes",
+                      "version": "1.5.8"
+                    },
+                    {
+                      "name": "calico",
+                      "version": "0.9.1"
+                    }
+                  ],
+                  "active": false
+                },
+                {
+                  "version": "2.8.4",
+                  "timestamp": "2017-11-11T12:24:56.59969Z",
+                  "changelog": [
+                    {
+                      "component": "calico",
+                      "description": "Bugfix"
+                    }
+                  ],
+                  "components": [
+                    {
+                      "name": "kubernetes",
+                      "version": "1.7.3"
+                    },
+                    {
+                      "name": "calico",
+                      "version": "1.1.1"
+                    }
+                  ],
+                  "active": true
+                }
+              ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+

--- a/fixtures/bugs/1621/parameters.yaml
+++ b/fixtures/bugs/1621/parameters.yaml
@@ -1,0 +1,61 @@
+parameters:
+
+  RequiredGiantSwarmAuthorizationHeader:
+    name: Authorization
+    type: string
+    in: header
+    required: true
+    description: As described in the [authentication](#section/Authentication) section
+
+  ClusterIdPathParameter:
+    name: cluster_id
+    in: path
+    required: true
+    type: string
+    description: Cluster ID
+
+  UserEmailPathParameter:
+    name: email
+    in: path
+    required: true
+    type: string
+    description: The user's email address
+
+  OrganizationIdPathParameter:
+    name: organization_id
+    in: path
+    required: true
+    type: string
+    description: |
+        An ID for the organization.
+        This ID must be unique and match this regular
+        expression: ^[a-z0-9_]{4,30}$
+
+  XRequestIDHeader:
+    name: X-Request-ID
+    in: header
+    type: string
+    required: false
+    description: |
+      A randomly generated key that can be used to track a request throughout
+      services of Giant Swarm.
+
+  XGiantSwarmActivityHeader:
+    name: X-Giant-Swarm-Activity
+    in: header
+    type: string
+    required: false
+    description: |
+      Name of an activity to track, like "list-clusters". This allows to
+      analyze several API requests sent in context and gives an idea on
+      the purpose.
+
+  XGiantSwarmCmdLineHeader:
+    name: X-Giant-Swarm-CmdLine
+    in: header
+    type: string
+    required: false
+    description: |
+      If activity has been issued by a CLI, this header can contain the
+      command line
+

--- a/fixtures/bugs/1621/responses.yaml
+++ b/fixtures/bugs/1621/responses.yaml
@@ -1,0 +1,13 @@
+responses:
+
+  V4Generic401Response:
+    description: Permission denied
+    schema:
+      $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    examples:
+      application/json:
+        {
+          "code": "PERMISSION_DENIED",
+          "message": "The requested resource cannot be accessed using the provided authentication details."
+        }
+

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -1683,73 +1683,165 @@ func TestFlatten_Bitbucket(t *testing.T) {
 	assert.True(t, ok)
 	_, ok = sp.Definitions["repository"]
 	assert.True(t, ok)
-	//bbb, _ := json.MarshalIndent(an.spec, "", " ")
-	//log.Printf(string(bbb))
 }
 
 func TestFlatten_Issue_1602(t *testing.T) {
-	// $ref in #/responses or #/parameters
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	// $ref as schema to #/responses or #/parameters
 
 	// minimal repro test case
 	bp := filepath.Join("fixtures", "bugs", "1602", "fixture-1602-1.yaml")
 	sp := loadOrFail(t, bp)
 	an := New(sp)
-	err := Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
-	//t.Logf("%s: %v", bp, err)
+	err := Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
 
 	// reload spec
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: false, Minimal: false, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: false, Minimal: false, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
 
 	// reload spec
 	// with  prior expansion, a pseudo schema is produced
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: false, Minimal: false, Expand: true, RemoveUnused: false})
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: false, Minimal: false, Expand: true,
+		RemoveUnused: false})
 	assert.NoError(t, err)
 
 	// full testcase
 	bp = filepath.Join("fixtures", "bugs", "1602", "fixture-1602-full.yaml")
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: false, Minimal: true, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: false, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
 
 	bp = filepath.Join("fixtures", "bugs", "1602", "fixture-1602-1.yaml")
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
-	//t.Logf("%s: %v", bp, err)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
 
 	bp = filepath.Join("fixtures", "bugs", "1602", "fixture-1602-2.yaml")
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
-	//t.Logf("%s: %v", bp, err)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
 
 	bp = filepath.Join("fixtures", "bugs", "1602", "fixture-1602-3.yaml")
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
-	//t.Logf("%s: %v", bp, err)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
 
 	bp = filepath.Join("fixtures", "bugs", "1602", "fixture-1602-4.yaml")
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
-	//t.Logf("%s: %v", bp, err)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
 
 	bp = filepath.Join("fixtures", "bugs", "1602", "fixture-1602-5.yaml")
 	sp = loadOrFail(t, bp)
 	an = New(sp)
-	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false, RemoveUnused: false})
-	assert.Error(t, err)
-	//t.Logf("%s: %v", bp, err)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
+
+	bp = filepath.Join("fixtures", "bugs", "1602", "fixture-1602-6.yaml")
+	sp = loadOrFail(t, bp)
+	an = New(sp)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
+}
+
+func TestFlatten_Issue_1614(t *testing.T) {
+	var logCapture bytes.Buffer
+	log.SetOutput(&logCapture)
+	defer log.SetOutput(os.Stdout)
+
+	// $ref as schema to #/responses or #/parameters
+	// test warnings
+
+	bp := filepath.Join("fixtures", "bugs", "1614", "gitea.yaml")
+	sp := loadOrFail(t, bp)
+	an := New(sp)
+	err := Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
+	msg := logCapture.String()
+	if !assert.Containsf(t, msg, `warning: found $ref "#/responses/empty" (response) interpreted as schema`,
+		"Expected log message") {
+		t.Logf("Captured log: %s", msg)
+	}
+	if !assert.Containsf(t, msg, `warning: found $ref "#/responses/forbidden" (response) interpreted as schema`,
+		"Expected log message") {
+		t.Logf("Captured log: %s", msg)
+	}
+
+	// check responses subject to warning have been expanded
+	bbb, _ := json.Marshal(sp)
+	assert.NotContains(t, string(bbb), `#/responses/forbidden`)
+	assert.NotContains(t, string(bbb), `#/responses/empty`)
+	//t.Logf("%v", string(bbb))
+}
+
+func TestFlatten_Issue_1621(t *testing.T) {
+	// repeated remote refs
+
+	// minimal repro test case
+	bp := filepath.Join("fixtures", "bugs", "1621", "fixture-1621.yaml")
+	sp := loadOrFail(t, bp)
+	an := New(sp)
+	err := Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, Expand: false,
+		RemoveUnused: false})
+	assert.NoError(t, err)
+
+	sch1 := sp.Paths.Paths["/v4/users/"].Get.Responses.StatusCodeResponses[200].Schema
+	bbb, _ := json.Marshal(sch1)
+	assert.JSONEq(t, `{
+			 "type": "array",
+			 "items": {
+			  "$ref": "#/definitions/v4UserListItem"
+			 }
+		 }`, string(bbb))
+
+	sch2 := sp.Paths.Paths["/v4/user/"].Get.Responses.StatusCodeResponses[200].Schema
+	bbb, _ = json.Marshal(sch2)
+	assert.JSONEq(t, `{
+			 "$ref": "#/definitions/v4UserListItem"
+			 }`, string(bbb))
+
+	sch3 := sp.Paths.Paths["/v4/users/{email}/"].Get.Responses.StatusCodeResponses[200].Schema
+	bbb, _ = json.Marshal(sch3)
+	assert.JSONEq(t, `{
+			 "$ref": "#/definitions/v4UserListItem"
+			 }`, string(bbb))
+}
+
+func Test_NormalizePath(t *testing.T) {
+	values := []struct{ Source, Expected string }{
+		{"#/definitions/A", "#/definitions/A"},
+		{"http://somewhere.com/definitions/A", "http://somewhere.com/definitions/A"},
+		{"/definitions/A", "/definitions/A"},
+		{"/definitions/errorModel.json#/definitions/A", "/definitions/errorModel.json#/definitions/A"},
+		{"http://somewhere.com", "http://somewhere.com"},
+		{"./definitions/definitions.yaml#/definitions/A", "/abs/to/spec/definitions/definitions.yaml#/definitions/A"},
+		{"#", "/abs/to/spec"},
+	}
+
+	for _, v := range values {
+		assert.Equal(t, v.Expected, normalizePath(spec.MustCreateRef(v.Source),
+			&FlattenOpts{BasePath: "/abs/to/spec/spec.json"}))
+	}
 }

--- a/hack/coverage
+++ b/hack/coverage
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e -o pipefail
+
+# Run test coverage on each subdirectories and merge the coverage profile.
+echo "mode: ${GOCOVMODE-atomic}" > coverage.txt
+
+# Standard go tooling behavior is to ignore dirs with leading underscores
+# skip generator for race detection and coverage
+for dir in $(go list ./...)
+do
+  pth="$GOPATH/src/$dir"
+  go test -v -race -timeout 20m -covermode=${GOCOVMODE-atomic} -coverprofile=${pth}/profile.out $dir
+  if [ -f $pth/profile.out ]
+  then
+      cat $pth/profile.out | tail -n +2 >> coverage.txt
+      rm $pth/profile.out
+  fi
+done
+go tool cover -func coverage.txt

--- a/internal/path_unescape_test.go
+++ b/internal/path_unescape_test.go
@@ -1,0 +1,27 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_PathUnescape(t *testing.T) {
+	res, err := PathUnescape("%7Babc%7D%2F%23%7B123%7D")
+	assert.NoError(t, err)
+	assert.Equal(t, "{abc}/#{123}", res)
+}

--- a/internal/post_go18.go
+++ b/internal/post_go18.go
@@ -1,0 +1,29 @@
+// +build go1.8
+
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "net/url"
+
+// PathUnescape provides url.PathUnescape(), with seamless
+// go version support for pre-go1.8
+//
+// TODO: this function is currently defined in go-openapi/swag,
+// but unexported. We might chose to export it, or simple phase
+// out pre-go1.8 support.
+func PathUnescape(path string) (string, error) {
+	return url.PathUnescape(path)
+}

--- a/internal/pre_go18.go
+++ b/internal/pre_go18.go
@@ -1,0 +1,29 @@
+// +build !go1.8
+
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "net/url"
+
+// PathUnescape provides url.PathUnescape(), with seamless
+// go version support for pre-go1.8
+//
+// TODO: this function is currently defined in go-openapi/swag,
+// but unexported. We might chose to export it, or simple phase
+// out pre-go1.8 support.
+func PathUnescape(path string) (string, error) {
+	return url.QueryUnescape(path)
+}


### PR DESCRIPTION
Fix flatten with pointers containing escaped chars (e.g. '{}')

Fixed undue duplicate name detection when resolving remote refs

Improves behavior in edge cases where schemas points to responses
or parameters.

This makes the flatten behavior consistent with swagger validate.

* now unmarshalls the struct as a schema: if this works, flattening
moves on, with a warning to the user (as this is valid but most
likely unintended)
* improves go-swagger/go-swagger#1602 and go-swagger/go-swagger#1614
* contributes go-swagger/go-swagger#1621
* Expand schemas when $ref'ed to (shared) responses or parameters