### PR TITLE
Add enum analysis

### DIFF
--- a/fixtures/enums.yml
+++ b/fixtures/enums.yml
@@ -1,0 +1,185 @@
+---
+swagger: "2.0"
+info:
+  version: "0.1.0"
+  title: reference analysis
+
+parameters:
+  idParam:
+    name: id
+    in: path
+    type: string
+    pattern: 'a[A-Za-Z0-9]+'
+    enum:
+      - aA
+      - b9
+      - c3
+
+responses:
+  notFound:
+    headers:
+      ContentLength:
+        type: string
+        pattern: '[0-9]+'
+        enum:
+          - '1234'
+          - '123'
+    schema:
+      $ref: "#/definitions/error"
+
+paths:
+  "/some/where/{id}":
+    parameters:
+      - $ref: "#/parameters/idParam"
+      - name: name
+        in: query
+        pattern: 'b[A-Za-z0-9]+'
+        enum:
+          - bA
+          - ba
+          - b9
+      - name: bodyId
+        in: body
+        schema:
+          type: object
+    get:
+      parameters:
+      - name: filter
+        in: query
+        type: string
+        pattern: "[abc][0-9]+"
+        enum:
+          - a0
+          - b1
+          - c2
+      - name: other
+        in: query
+        type: array
+        items:
+          type: string
+          pattern: 'c[A-Za-z0-9]+'
+          enum:
+            - cA
+            - cz
+            - c9
+        enum:
+          -
+            - cA
+            - cz
+            - c9
+          -
+            - cA
+            - cz
+          -
+            - cz
+            - c9
+      - name: body
+        in: body
+        schema:
+          type: object
+          enum:
+            - '{"a": 10, "b": 20}'
+            - '{"a": 11, "d": "zzz"}'
+            
+      responses:
+        default:
+          schema:
+            type: object
+        404:
+          $ref: "#/responses/notFound"
+        200:
+          headers:
+            X-Request-Id:
+              type: string
+              pattern: 'd[A-Za-z0-9]+'
+              enum:
+                - dA
+                - d9
+          schema:
+            $ref: "#/definitions/tag"
+  "/other/place":
+    post:
+      parameters:
+        - name: body
+          in: body
+          schema:
+            type: object
+            properties:
+              value:
+                type: string
+                pattern: 'e[A-Za-z0-9]+'
+                enum:
+                  - eA
+                  - e9
+      responses:
+        default:
+          headers:
+            Via:
+              type: array
+              items:
+                type: string
+                pattern: '[A-Za-z]+'
+                enum:
+                  - AA
+                  - Ab
+        200:
+          schema:
+            type: object
+            properties:
+              data:
+                type: string
+                pattern: "[0-9]+[abd]"
+                enum:
+                  - 123a
+                  - 123b
+                  - 123d
+definitions:
+  named:
+    type: string
+    pattern: 'f[A-Za-z0-9]+'
+    enum:
+      - fA
+      - f9
+  tag:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      value:
+        type: string
+        pattern: 'g[A-Za-z0-9]+'
+        enum:
+          - gA
+          - ga
+          - g9
+      audit:
+        $ref: "#/definitions/record"
+  record:
+    type: object
+    properties:
+      createdAt:
+        type: string
+        format: date
+    enum:
+      - '{"createdAt": "2018-08-31"}'
+      - '{"createdAt": "2018-09-30"}'
+  error:
+    type: object
+    required:
+      - id
+      - message
+    properties:
+      id:
+        type: integer
+        format: int64
+        readOnly: true
+      message:
+        type: string
+        readOnly: true
+  withPatternProperties:
+    type: object
+    additionalProperties: true
+    patternProperties:
+      '^prop[0-9]+$':
+        type: string

--- a/flatten.go
+++ b/flatten.go
@@ -512,7 +512,10 @@ const (
 	definitionsPath = "#/definitions"
 )
 
-var ignoredKeys map[string]struct{}
+var (
+	ignoredKeys  map[string]struct{}
+	validMethods map[string]struct{}
+)
 
 func init() {
 	ignoredKeys = map[string]struct{}{
@@ -521,6 +524,16 @@ func init() {
 		"not":        {},
 		"anyOf":      {},
 		"oneOf":      {},
+	}
+
+	validMethods = map[string]struct{}{
+		"GET":     {},
+		"HEAD":    {},
+		"OPTIONS": {},
+		"PATCH":   {},
+		"POST":    {},
+		"PUT":     {},
+		"DELETE":  {},
 	}
 }
 
@@ -619,26 +632,12 @@ func (s splitKey) ResponseName() string {
 	return ""
 }
 
-var validMethods map[string]struct{}
-
-func init() {
-	validMethods = map[string]struct{}{
-		"GET":     {},
-		"HEAD":    {},
-		"OPTIONS": {},
-		"PATCH":   {},
-		"POST":    {},
-		"PUT":     {},
-		"DELETE":  {},
-	}
-}
-
 func (s splitKey) PathItemRef() swspec.Ref {
 	if len(s) < 3 {
 		return swspec.Ref{}
 	}
 	pth, method := s[1], s[2]
-	if _, validMethod := validMethods[strings.ToUpper(method)]; !validMethod && !strings.HasPrefix(method, "x-") {
+	if _, isValidMethod := validMethods[strings.ToUpper(method)]; !isValidMethod && !strings.HasPrefix(method, "x-") {
 		return swspec.Ref{}
 	}
 	return swspec.MustCreateRef("#" + slashpath.Join("/", paths, jsonpointer.Escape(pth), strings.ToUpper(method)))


### PR DESCRIPTION
This feature is going to be used to detect conflicts with generated enum names in go-swagger

- also fix race condition in flatten (which is of no practical use atm, since spec expand is not parallelizable)