### PR TITLE
Iterate remote ref resolve

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
   golint:
     min-confidence: 0
   gocyclo:
-    min-complexity: 30
+    min-complexity: 40
   maligned:
     suggest-new: true
   dupl:
@@ -17,5 +17,6 @@ linters:
   enable-all: true
   disable:
     - maligned
+    - lll
     - gochecknoglobals
     - gochecknoinits

--- a/analyzer.go
+++ b/analyzer.go
@@ -142,38 +142,12 @@ func (p *enumAnalysis) addSchemaEnum(key string, enum []interface{}) {
 // or validation etc.
 func New(doc *spec.Swagger) *Spec {
 	a := &Spec{
-		spec:        doc,
-		consumes:    make(map[string]struct{}, 150),
-		produces:    make(map[string]struct{}, 150),
-		authSchemes: make(map[string]struct{}, 150),
-		operations:  make(map[string]map[string]*spec.Operation, 150),
-		allSchemas:  make(map[string]SchemaRef, 150),
-		allOfs:      make(map[string]SchemaRef, 150),
-		references: referenceAnalysis{
-			schemas:        make(map[string]spec.Ref, 150),
-			pathItems:      make(map[string]spec.Ref, 150),
-			responses:      make(map[string]spec.Ref, 150),
-			parameters:     make(map[string]spec.Ref, 150),
-			items:          make(map[string]spec.Ref, 150),
-			headerItems:    make(map[string]spec.Ref, 150),
-			parameterItems: make(map[string]spec.Ref, 150),
-			allRefs:        make(map[string]spec.Ref, 150),
-		},
-		patterns: patternAnalysis{
-			parameters:  make(map[string]string, 150),
-			headers:     make(map[string]string, 150),
-			items:       make(map[string]string, 150),
-			schemas:     make(map[string]string, 150),
-			allPatterns: make(map[string]string, 150),
-		},
-		enums: enumAnalysis{
-			parameters: make(map[string][]interface{}, 150),
-			headers:    make(map[string][]interface{}, 150),
-			items:      make(map[string][]interface{}, 150),
-			schemas:    make(map[string][]interface{}, 150),
-			allEnums:   make(map[string][]interface{}, 150),
-		},
+		spec:       doc,
+		references: referenceAnalysis{},
+		patterns:   patternAnalysis{},
+		enums:      enumAnalysis{},
 	}
+	a.reset()
 	a.initialize()
 	return a
 }

--- a/fixtures/bugs/1851/definitions-3.yaml
+++ b/fixtures/bugs/1851/definitions-3.yaml
@@ -1,0 +1,19 @@
+definitions:
+  ServerStatus:
+    type: string
+    enum: [OK, Not OK]
+
+  Server:
+    type: object
+    properties:
+      Name:
+        type: string
+      Status:
+        $ref: '#/definitions/ServerStatus'
+      # introduce a circular ref here
+      SiblingServer:
+        $ref: '#/definitions/Server'
+      # introduce a nest ref here
+      RemoteProps:
+        $ref: 'definitions-31.yaml#/definitions/RemoteProperty'
+        # TODO: same with absolute ref (e.g. http://...)

--- a/fixtures/bugs/1851/definitions-31.yaml
+++ b/fixtures/bugs/1851/definitions-31.yaml
@@ -1,0 +1,12 @@
+definitions:
+  RemoteProperty:
+    type: object
+    properties:
+      RemoteName:
+        type: string
+      MoreRemoteName:
+        $ref: 'remote/definitions-32.yaml#/definitions/MoreRemoteProperty'
+      # introduce a circular ref here
+      RemoteCircular:
+        $ref: '#/definitions/RemoteProperty'
+        # TODO: same with circular in a remote

--- a/fixtures/bugs/1851/definitions.yaml
+++ b/fixtures/bugs/1851/definitions.yaml
@@ -1,0 +1,12 @@
+definitions:
+  ServerStatus:
+    type: string
+    enum: [OK, Not OK]
+
+  Server:
+    type: object
+    properties:
+      Name:
+        type: string
+      Status:
+        $ref: '#/definitions/ServerStatus'

--- a/fixtures/bugs/1851/fixture-1851-2.yaml
+++ b/fixtures/bugs/1851/fixture-1851-2.yaml
@@ -1,0 +1,51 @@
+swagger: '2.0'
+
+info:
+  title: 'Title'
+  version: '1.0'
+
+paths:
+  '/':
+    get:
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+    post:
+      parameters:
+        - in: body
+          schema:
+            $ref: '#/definitions/Request'
+          name: filter
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+
+definitions:
+  Response:
+    type: object
+    properties:
+      Server:
+        type: array
+        items:
+          $ref: '#/definitions/Server'
+  Request:
+    type: object
+    properties:
+      ServerStatus:
+        $ref: '#/definitions/ServerStatus'
+
+  ServerStatus:
+    type: string
+    enum: [OK, Not OK]
+
+  Server:
+    type: object
+    properties:
+      Name:
+        type: string
+      Status:
+        $ref: '#/definitions/ServerStatus'

--- a/fixtures/bugs/1851/fixture-1851-3.yaml
+++ b/fixtures/bugs/1851/fixture-1851-3.yaml
@@ -1,0 +1,39 @@
+swagger: '2.0'
+
+info:
+  title: 'Title'
+  version: '1.0'
+
+paths:
+  '/':
+    get:
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+    post:
+      parameters:
+        - in: body
+          schema:
+            $ref: '#/definitions/Request'
+          name: filter
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+
+definitions:
+  Response:
+    type: object
+    properties:
+      Server:
+        type: array
+        items:
+          $ref: 'definitions-3.yaml#/definitions/Server'
+  Request:
+    type: object
+    properties:
+      ServerStatus:
+        $ref: 'definitions-3.yaml#/definitions/ServerStatus'

--- a/fixtures/bugs/1851/fixture-1851.yaml
+++ b/fixtures/bugs/1851/fixture-1851.yaml
@@ -1,0 +1,39 @@
+swagger: '2.0'
+
+info:
+  title: 'Title'
+  version: '1.0'
+
+paths:
+  '/':
+    get:
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+    post:
+      parameters:
+        - in: body
+          schema:
+            $ref: '#/definitions/Request'
+          name: filter
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+
+definitions:
+  Response:
+    type: object
+    properties:
+      Server:
+        type: array
+        items:
+          $ref: 'definitions.yaml#/definitions/Server'
+  Request:
+    type: object
+    properties:
+      ServerStatus:
+        $ref: 'definitions.yaml#/definitions/ServerStatus'

--- a/fixtures/bugs/1851/remote/definitions-32.yaml
+++ b/fixtures/bugs/1851/remote/definitions-32.yaml
@@ -1,0 +1,3 @@
+definitions:
+  MoreRemoteProperty:
+    type: string

--- a/fixtures/external_definitions_valid.yml
+++ b/fixtures/external_definitions_valid.yml
@@ -29,8 +29,9 @@ paths:
       - name: other
         in: query
         type: array
+        # $ref in parameter array items is not swagger 2.0 compliant
         items:
-          $ref: "external/definitions.yml#/definitions/named"
+          type: string
       - name: body
         in: body
         schema:

--- a/flatten.go
+++ b/flatten.go
@@ -145,7 +145,6 @@ func Flatten(opts FlattenOpts) error {
 
 	// recursively expand responses, parameters, path items and items in simple schemas.
 	// This simplifies the spec and leaves $ref only into schema objects.
-	//
 	if err := swspec.ExpandSpec(opts.Swagger(), opts.ExpandOpts(!opts.Expand)); err != nil {
 		return err
 	}
@@ -165,8 +164,11 @@ func Flatten(opts FlattenOpts) error {
 
 	opts.Spec.reload() // re-analyze
 
-	// at this point there are no other references left but schemas
+	// at this point there are no references left but in schemas
+
 	for imported := false; !imported; {
+		// iteratively import remote references until none left.
+		// This inlining deals with name conflicts by introducing auto-generated names ("OAIGen")
 		var err error
 		if imported, err = importExternalReferences(&opts); err != nil {
 			return err
@@ -182,8 +184,9 @@ func Flatten(opts FlattenOpts) error {
 
 		opts.Spec.reload() // re-analyze
 	}
+
 	// rewrite JSON pointers other than $ref to named definitions
-	// and attempts to resolve conflicting names
+	// and attempt to resolve conflicting names whenever possible.
 	if err := stripPointersAndOAIGen(&opts); err != nil {
 		return err
 	}
@@ -362,6 +365,7 @@ func (isn *inlineSchemaNamer) Name(key string, schema *swspec.Schema, aschema *A
 
 			// rewrite any dependent $ref pointing to this place,
 			// when not already pointing to a top-level definition.
+			//
 			// NOTE: this is important if such referers use arbitrary JSON pointers.
 			an := New(isn.Spec)
 			for k, v := range an.references.allRefs {
@@ -373,6 +377,7 @@ func (isn *inlineSchemaNamer) Name(key string, schema *swspec.Schema, aschema *A
 					r.String() == slashpath.Join(definitionsPath, newName) &&
 						slashpath.Dir(v.String()) != definitionsPath {
 					debugLog("found a $ref to a rewritten schema: %s points to %s", k, v.String())
+
 					// rewrite $ref to the new target
 					if err := updateRef(isn.Spec, k,
 						swspec.MustCreateRef(slashpath.Join(definitionsPath, newName))); err != nil {
@@ -383,6 +388,7 @@ func (isn *inlineSchemaNamer) Name(key string, schema *swspec.Schema, aschema *A
 
 			// NOTE: this extension is currently not used by go-swagger (provided for information only)
 			sch.AddExtension("x-go-gen-location", genLocation(parts))
+
 			// save cloned schema to definitions
 			saveSchema(isn.Spec, newName, sch)
 
@@ -408,6 +414,7 @@ func (isn *inlineSchemaNamer) Name(key string, schema *swspec.Schema, aschema *A
 }
 
 // genLocation indicates from which section of the specification (models or operations) a definition has been created.
+//
 // This is reflected in the output spec with a "x-go-gen-location" extension. At the moment, this is is provided
 // for information only.
 func genLocation(parts splitKey) string {
@@ -420,6 +427,7 @@ func genLocation(parts splitKey) string {
 	return ""
 }
 
+// uniqifyName yields a unique name for a definition
 func uniqifyName(definitions swspec.Definitions, name string) (string, bool) {
 	isOAIGen := false
 	if name == "" {
@@ -781,7 +789,14 @@ func cloneSchema(schema *swspec.Schema) (*swspec.Schema, error) {
 	return &sch, nil
 }
 
+// importExternalReferences iteratively digs remote references and imports them into the main schema.
+//
+// At every iteration, new remotes may be found when digging deeper: they are rebased to the current schema before being imported.
+//
+// This returns true when no more remote references can be found.
 func importExternalReferences(opts *FlattenOpts) (bool, error) {
+	debugLog("importExternalReferences")
+
 	groupedRefs := reverseIndexForSchemaRefs(opts)
 	sortedRefStr := make([]string, 0, len(groupedRefs))
 	if opts.flattenContext == nil {
@@ -795,77 +810,158 @@ func importExternalReferences(opts *FlattenOpts) (bool, error) {
 	sort.Strings(sortedRefStr)
 
 	complete := true
+
 	for _, refStr := range sortedRefStr {
 		entry := groupedRefs[refStr]
-		if !entry.Ref.HasFragmentOnly {
-			complete = false
-			var isOAIGen bool
+		if entry.Ref.HasFragmentOnly {
+			continue
+		}
+		complete = false
+		var isOAIGen bool
 
-			newName := opts.flattenContext.resolved[refStr]
-			if newName != "" {
-				// rewrite ref with already resolved external ref (useful for cyclicali refs)
-				debugLog("resolving known ref [%s] to %s", refStr, newName)
-				// rewrite the external refs to local ones
-				for _, key := range entry.Keys {
-					if err := updateRef(opts.Swagger(), key,
-						swspec.MustCreateRef(slashpath.Join(definitionsPath, newName))); err != nil {
-						return false, err
-					}
-				}
-			} else {
-				debugLog("importing external schema for [%s] from %s", strings.Join(entry.Keys, ", "), refStr)
-
-				// resolve to actual schema
-				sch := new(swspec.Schema)
-				sch.Ref = entry.Ref
-				if err := swspec.ExpandSchemaWithBasePath(sch, nil, opts.ExpandOpts(false)); err != nil {
+		newName := opts.flattenContext.resolved[refStr]
+		if newName != "" {
+			// rewrite ref with already resolved external ref (useful for cyclical refs):
+			// rewrite external refs to local ones
+			debugLog("resolving known ref [%s] to %s", refStr, newName)
+			for _, key := range entry.Keys {
+				if err := updateRef(opts.Swagger(), key,
+					swspec.MustCreateRef(slashpath.Join(definitionsPath, newName))); err != nil {
 					return false, err
 				}
-				if sch == nil {
-					return false, fmt.Errorf("no schema found at %s for [%s]", refStr, strings.Join(entry.Keys, ", "))
-				}
-				debugLog("importing external schema for [%s] from %s", strings.Join(entry.Keys, ", "), refStr)
-
-				// generate a unique name - isOAIGen means that a naming conflict was resolved by changing the name
-				newName, isOAIGen = uniqifyName(opts.Swagger().Definitions, nameFromRef(entry.Ref))
-				debugLog("new name for [%s]: %s - with name conflict:%t",
-					strings.Join(entry.Keys, ", "), newName, isOAIGen)
-
-				opts.flattenContext.resolved[refStr] = newName
-
-				// rewrite the external refs to local ones
-				for _, key := range entry.Keys {
-					if err := updateRef(opts.Swagger(), key,
-						swspec.MustCreateRef(slashpath.Join(definitionsPath, newName))); err != nil {
-						return false, err
-					}
-
-					// keep track of created refs
-					resolved := false
-					if _, ok := opts.flattenContext.newRefs[key]; ok {
-						resolved = opts.flattenContext.newRefs[key].resolved
-					}
-					opts.flattenContext.newRefs[key] = &newRef{
-						key:      key,
-						newName:  newName,
-						path:     slashpath.Join(definitionsPath, newName),
-						isOAIGen: isOAIGen,
-						resolved: resolved,
-						schema:   sch,
-					}
-				}
-
-				// add the resolved schema to the definitions
-				saveSchema(opts.Swagger(), newName, sch)
 			}
+		} else {
+			// resolve schemas
+			debugLog("resolving schema from remote $ref [%s]", refStr)
+			sch, err := swspec.ResolveRefWithBase(opts.Swagger(), &entry.Ref, opts.ExpandOpts(false))
+			if err != nil {
+				return false, fmt.Errorf("could not resolve schema: %v", err)
+			}
+
+			// at this stage only $ref analysis matters
+			partialAnalyzer := &Spec{
+				references: referenceAnalysis{},
+				patterns:   patternAnalysis{},
+				enums:      enumAnalysis{},
+			}
+			partialAnalyzer.reset()
+			partialAnalyzer.analyzeSchema("", *sch, "/")
+
+			// now rewrite those refs with rebase
+			for key, ref := range partialAnalyzer.references.allRefs {
+				if err := updateRef(sch, key, swspec.MustCreateRef(rebaseRef(entry.Ref.String(), ref.String()))); err != nil {
+					return false, fmt.Errorf("failed to rewrite ref for key %q at %s: %v", key, entry.Ref.String(), err)
+				}
+			}
+
+			// generate a unique name - isOAIGen means that a naming conflict was resolved by changing the name
+			newName, isOAIGen = uniqifyName(opts.Swagger().Definitions, nameFromRef(entry.Ref))
+			debugLog("new name for [%s]: %s - with name conflict:%t",
+				strings.Join(entry.Keys, ", "), newName, isOAIGen)
+
+			opts.flattenContext.resolved[refStr] = newName
+
+			// rewrite the external refs to local ones
+			for _, key := range entry.Keys {
+				if err := updateRef(opts.Swagger(), key,
+					swspec.MustCreateRef(slashpath.Join(definitionsPath, newName))); err != nil {
+					return false, err
+				}
+
+				// keep track of created refs
+				resolved := false
+				if _, ok := opts.flattenContext.newRefs[key]; ok {
+					resolved = opts.flattenContext.newRefs[key].resolved
+				}
+				opts.flattenContext.newRefs[key] = &newRef{
+					key:      key,
+					newName:  newName,
+					path:     slashpath.Join(definitionsPath, newName),
+					isOAIGen: isOAIGen,
+					resolved: resolved,
+					schema:   sch,
+				}
+			}
+
+			// add the resolved schema to the definitions
+			saveSchema(opts.Swagger(), newName, sch)
 		}
 	}
+	// maintains ref index entries
+	for k := range opts.flattenContext.newRefs {
+		r := opts.flattenContext.newRefs[k]
+
+		// update tracking with resolved schemas
+		if r.schema.Ref.String() != "" {
+			ref := swspec.MustCreateRef(r.path)
+			sch, err := swspec.ResolveRefWithBase(opts.Swagger(), &ref, opts.ExpandOpts(false))
+			if err != nil {
+				return false, fmt.Errorf("could not resolve schema: %v", err)
+			}
+			r.schema = sch
+		}
+		// update tracking with renamed keys: got a cascade of refs
+		if r.path != k {
+			renamed := *r
+			renamed.key = r.path
+			opts.flattenContext.newRefs[renamed.path] = &renamed
+
+			// indirect ref
+			r.newName = slashpath.Base(k)
+			r.schema = swspec.RefSchema(r.path)
+			r.path = k
+			r.isOAIGen = strings.Contains(k, "OAIGen")
+		}
+	}
+
 	return complete, nil
 }
 
 type refRevIdx struct {
 	Ref  swspec.Ref
 	Keys []string
+}
+
+// rebaseRef rebase a remote ref relative to a base ref.
+//
+// NOTE: does not support JSONschema ID for $ref (we assume we are working with swagger specs here).
+func rebaseRef(baseRef string, ref string) string {
+	if baseRef == "" || baseRef == "." || strings.HasPrefix(baseRef, "#") {
+		return ref
+	}
+
+	parts := strings.Split(ref, "#")
+
+	baseParts := strings.Split(baseRef, "#")
+	baseURL, _ := url.Parse(baseParts[0])
+	if strings.HasPrefix(ref, "#") {
+		if baseURL.Host == "" {
+			return strings.Join([]string{baseParts[0], parts[1]}, "#")
+		}
+		return strings.Join([]string{baseParts[0], parts[1]}, "")
+	}
+
+	refURL, _ := url.Parse(parts[0])
+	if refURL.Host != "" || filepath.IsAbs(parts[0]) {
+		// not rebasing an absolute path
+		return ref
+	}
+
+	// there is a relative path
+	var basePath string
+	if baseURL.Host != "" {
+		baseURL.Path = slashpath.Dir(baseURL.Path)
+		baseURL.Path = slashpath.Join(baseURL.Path, "/"+parts[0])
+		return baseURL.String()
+	}
+
+	basePath = filepath.Dir(baseParts[0])
+
+	relPath := slashpath.Join(basePath, "/"+parts[0])
+	if len(parts) > 1 {
+		return strings.Join([]string{relPath, parts[1]}, "#")
+	}
+	return relPath
 }
 
 // normalizePath renders absolute path on remote file refs
@@ -935,7 +1031,16 @@ func saveSchema(spec *swspec.Swagger, name string, schema *swspec.Schema) {
 }
 
 // getPointerFromKey retrieves the content of the JSON pointer "key"
-func getPointerFromKey(spec *swspec.Swagger, key string) (string, interface{}, error) {
+func getPointerFromKey(spec interface{}, key string) (string, interface{}, error) {
+	switch spec.(type) {
+	case *swspec.Schema:
+	case *swspec.Swagger:
+	default:
+		panic("unexpected type used in getPointerFromKey")
+	}
+	if key == "#/" {
+		return "", spec, nil
+	}
 	// unescape chars in key, e.g. "{}" from path params
 	pth, _ := internal.PathUnescape(key[1:])
 	ptr, err := jsonpointer.New(pth)
@@ -952,7 +1057,13 @@ func getPointerFromKey(spec *swspec.Swagger, key string) (string, interface{}, e
 }
 
 // getParentFromKey retrieves the container of the JSON pointer "key"
-func getParentFromKey(spec *swspec.Swagger, key string) (string, string, interface{}, error) {
+func getParentFromKey(spec interface{}, key string) (string, string, interface{}, error) {
+	switch spec.(type) {
+	case *swspec.Schema:
+	case *swspec.Swagger:
+	default:
+		panic("unexpected type used in getPointerFromKey")
+	}
 	// unescape chars in key, e.g. "{}" from path params
 	pth, _ := internal.PathUnescape(key[1:])
 
@@ -971,7 +1082,13 @@ func getParentFromKey(spec *swspec.Swagger, key string) (string, string, interfa
 }
 
 // updateRef replaces a ref by another one
-func updateRef(spec *swspec.Swagger, key string, ref swspec.Ref) error {
+func updateRef(spec interface{}, key string, ref swspec.Ref) error {
+	switch spec.(type) {
+	case *swspec.Schema:
+	case *swspec.Swagger:
+	default:
+		panic("unexpected type used in getPointerFromKey")
+	}
 	debugLog("updating ref for %s with %s", key, ref.String())
 	pth, value, err := getPointerFromKey(spec, key)
 	if err != nil {
@@ -1165,6 +1282,7 @@ func stripPointersAndOAIGen(opts *FlattenOpts) error {
 	// iterate as pointer or OAIGen resolution may introduce inline schemas or pointers
 	for hasIntroducedPointerOrInline {
 		if !opts.Minimal {
+			opts.Spec.reload() // re-analyze
 			if err := nameInlinedSchemas(opts); err != nil {
 				return err
 			}
@@ -1178,60 +1296,119 @@ func stripPointersAndOAIGen(opts *FlattenOpts) error {
 		if hasIntroducedPointerOrInline, ers = stripOAIGen(opts); ers != nil {
 			return ers
 		}
+
+		opts.Spec.reload() // re-analyze
 	}
 	return nil
 }
 
 // stripOAIGen strips the spec from unnecessary OAIGen constructs, initially created to dedupe flattened definitions.
+//
 // A dedupe is deemed unnecessary whenever:
 //  - the only conflict is with its (single) parent: OAIGen is merged into its parent
 //  - there is a conflict with multiple parents: merge OAIGen in first parent, the rewrite other parents to point to
 //    the first parent.
 //
 // This function returns a true bool whenever it re-inlined a complex schema, so the caller may chose to iterate
-// flattening again.
-//
-// NOTE: the OAIGen definition cannot be itself a $ref.
+// pointer and name resolution again.
 func stripOAIGen(opts *FlattenOpts) (bool, error) {
 	debugLog("stripOAIGen")
 	replacedWithComplex := false
-	for k, v := range opts.Spec.references.allRefs {
-		// figure out referers of OAIGen definitions
-		for _, r := range opts.flattenContext.newRefs {
-			if r.isOAIGen && !r.resolved && r.path == v.String() { // bail on already resolved entries (avoid looping)
+
+	// figure out referers of OAIGen definitions
+	for _, r := range opts.flattenContext.newRefs {
+		if !r.isOAIGen || r.resolved { // bail on already resolved entries (avoid looping)
+			continue
+		}
+		for k, v := range opts.Spec.references.allRefs {
+			if r.path != v.String() {
+				continue
+			}
+			found := false
+			for _, p := range r.parents {
+				if p == k {
+					found = true
+					break
+				}
+			}
+			if !found {
 				r.parents = append(r.parents, k)
 			}
 		}
 	}
 
-	for _, r := range opts.flattenContext.newRefs {
-		if r.isOAIGen && len(r.parents) >= 1 && r.schema.Ref.String() == "" {
+	for k := range opts.flattenContext.newRefs {
+		r := opts.flattenContext.newRefs[k]
+		//debugLog("newRefs[%s]: isOAIGen: %t, resolved: %t, name: %s, path:%s, #parents: %d, parents: %v,  ref: %s",
+		//	k, r.isOAIGen, r.resolved, r.newName, r.path, len(r.parents), r.parents, r.schema.Ref.String())
+		if r.isOAIGen && len(r.parents) >= 1 /*&& r.schema.Ref.String() == "" */ {
 			pr := r.parents
 			sort.Strings(pr)
+
 			// rewrite first parent schema in lexicographical order
 			debugLog("rewrite first parent %s with schema", pr[0])
 			if err := updateRefWithSchema(opts.Swagger(), pr[0], r.schema); err != nil {
 				return false, err
 			}
+			if pa, ok := opts.flattenContext.newRefs[pr[0]]; ok && pa.isOAIGen {
+				// update parent in ref index entry
+				debugLog("update parent entry: %s", pr[0])
+				pa.schema = r.schema
+				pa.resolved = false
+				replacedWithComplex = true
+			}
+
 			// rewrite other parents to point to first parent
 			if len(pr) > 1 {
 				for _, p := range pr[1:] {
 					replacingRef := swspec.MustCreateRef(pr[0])
-					// Set complex when replacing ref is an anonymous jsonpointer: further processing may be required
+
+					// set complex when replacing ref is an anonymous jsonpointer: further processing may be required
 					replacedWithComplex = replacedWithComplex ||
 						slashpath.Dir(replacingRef.String()) != definitionsPath
 					debugLog("rewrite parent with ref: %s", replacingRef.String())
+
 					// NOTE: it is possible at this stage to introduce json pointers (to non-definitions places).
 					// Those are stripped later on.
 					if err := updateRef(opts.Swagger(), p, replacingRef); err != nil {
 						return false, err
 					}
+
+					if pa, ok := opts.flattenContext.newRefs[p]; ok && pa.isOAIGen {
+						// update parent in ref index
+						debugLog("update parent entry: %s", p)
+						pa.schema = r.schema
+						pa.resolved = false
+						replacedWithComplex = true
+					}
 				}
 			}
+
 			// remove OAIGen definition
 			debugLog("removing definition %s", slashpath.Base(r.path))
 			delete(opts.Swagger().Definitions, slashpath.Base(r.path))
+
+			// propagate changes in ref index for keys which have this one as a parent
+			for kk, value := range opts.flattenContext.newRefs {
+				if kk == k || !value.isOAIGen || value.resolved {
+					continue
+				}
+				found := false
+				newParents := make([]string, 0, len(value.parents))
+				for _, parent := range value.parents {
+					if parent == r.path {
+						found = true
+						parent = pr[0]
+					}
+					newParents = append(newParents, parent)
+				}
+				if found {
+					value.parents = newParents
+				}
+			}
+
 			// mark naming conflict as resolved
+			debugLog("marking naming conflict resolved for key: %s", r.key)
 			opts.flattenContext.newRefs[r.key].isOAIGen = false
 			opts.flattenContext.newRefs[r.key].resolved = true
 
@@ -1247,6 +1424,8 @@ func stripOAIGen(opts *FlattenOpts) (bool, error) {
 			}
 		}
 	}
+
+	debugLog("replacedWithComplex: %t", replacedWithComplex)
 	opts.Spec.reload() // re-analyze
 	return replacedWithComplex, nil
 }
@@ -1338,6 +1517,14 @@ func namePointers(opts *FlattenOpts) error {
 			debugLog("namePointers at %s for %s", key, v.Ref.String())
 
 			// qualify the expanded schema
+			/*
+				if key == "#/paths/~1some~1where~1{id}/get/parameters/1/items" {
+					// DEBUG
+					//func getPointerFromKey(spec interface{}, key string) (string, interface{}, error) {
+					k, res, err := getPointerFromKey(namer.Spec, key)
+					debugLog("k = %s, res=%#v, err=%v", k, res, err)
+				}
+			*/
 			asch, ers := Schema(SchemaOpts{Schema: v.Schema, Root: opts.Swagger(), BasePath: opts.BasePath})
 			if ers != nil {
 				return fmt.Errorf("schema analysis [%s]: %v", key, ers)

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -125,43 +125,45 @@ func TestUpdateRef(t *testing.T) {
 }
 
 func TestImportExternalReferences(t *testing.T) {
-	bp := filepath.Join(".", "fixtures", "external_definitions.yml")
+	// this fixture is the same as external_definitions.yml, but no more
+	// checks if invalid construct is supported (i.e. $ref in parameters items)
+	bp := filepath.Join(".", "fixtures", "external_definitions_valid.yml")
 	sp, err := loadSpec(bp)
-	if assert.NoError(t, err) {
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	opts := &FlattenOpts{
+		Spec:     New(sp),
+		BasePath: bp,
+	}
+	// NOTE(fredbi): now we no more expand, but merely resolve and iterate until there is no more ext ref
+	// so calling importExternalReferences is no more idempotent
+	_, err = importExternalReferences(opts)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
 
-		for i, v := range refFixture {
-			// there is 1 notable difference with the updateRef test:
-			if i == 5 {
-				v.Ref = spec.MustCreateRef("#/definitions/tag")
-			}
-			// technically not necessary to run for each value, but if things go right
-			// this is idempotent, so having it repeat shouldn't matter
-			// this validates that behavior
-			_, err := importExternalReferences(&FlattenOpts{
-				Spec:     New(sp),
-				BasePath: bp,
-			})
+	for i, v := range refFixture {
+		// there is 1 notable difference with the updateRef test:
+		if i == 5 {
+			v.Ref = spec.MustCreateRef("#/definitions/tag")
+		}
 
-			if assert.NoError(t, err) {
-
-				ptr, err := jsonpointer.New(v.Key[1:])
-				if assert.NoError(t, err) {
-					vv, _, err := ptr.Get(sp)
-
-					if assert.NoError(t, err) {
-						switch tv := vv.(type) {
-						case *spec.Schema:
-							assert.Equal(t, v.Ref.String(), tv.Ref.String(), "for %s", v.Key)
-						case spec.Schema:
-							assert.Equal(t, v.Ref.String(), tv.Ref.String(), "for %s", v.Key)
-						case *spec.SchemaOrBool:
-							assert.Equal(t, v.Ref.String(), tv.Schema.Ref.String(), "for %s", v.Key)
-						case *spec.SchemaOrArray:
-							assert.Equal(t, v.Ref.String(), tv.Schema.Ref.String(), "for %s", v.Key)
-						default:
-							assert.Fail(t, "unknown type", "got %T", vv)
-						}
-					}
+		ptr, erj := jsonpointer.New(v.Key[1:])
+		if assert.NoErrorf(t, erj, "error on jsonpointer.New(%q)", v.Key[1:]) {
+			vv, _, erg := ptr.Get(sp)
+			if assert.NoErrorf(t, erg, "error on ptr.Get(p for key=%s)", v.Key[1:]) {
+				switch tv := vv.(type) {
+				case *spec.Schema:
+					assert.Equal(t, v.Ref.String(), tv.Ref.String(), "for %s", v.Key)
+				case spec.Schema:
+					assert.Equal(t, v.Ref.String(), tv.Ref.String(), "for %s", v.Key)
+				case *spec.SchemaOrBool:
+					assert.Equal(t, v.Ref.String(), tv.Schema.Ref.String(), "for %s", v.Key)
+				case *spec.SchemaOrArray:
+					assert.Equal(t, v.Ref.String(), tv.Schema.Ref.String(), "for %s", v.Key)
+				default:
+					assert.Fail(t, "unknown type", "got %T", vv)
 				}
 			}
 		}
@@ -170,6 +172,339 @@ func TestImportExternalReferences(t *testing.T) {
 		assert.Contains(t, sp.Definitions, "named")
 		assert.Contains(t, sp.Definitions, "record")
 	}
+
+	// check the complete result for clarity
+	bb, _ := json.MarshalIndent(sp, "", " ")
+	assert.JSONEq(t, `{
+         "swagger": "2.0",
+         "info": {
+          "title": "reference analysis",
+          "version": "0.1.0"
+         },
+         "paths": {
+          "/other/place": {
+           "$ref": "external/pathItem.yml"
+          },
+          "/some/where/{id}": {
+           "get": {
+            "parameters": [
+             {
+              "$ref": "external/parameters.yml#/parameters/limitParam"
+             },
+             {
+              "type": "array",
+              "items": {
+               "type": "string"
+              },
+              "name": "other",
+              "in": "query"
+             },
+             {
+              "name": "body",
+              "in": "body",
+              "schema": {
+               "$ref": "#/definitions/record"
+              }
+             }
+            ],
+            "responses": {
+             "200": {
+              "schema": {
+               "$ref": "#/definitions/tag"
+              }
+             },
+             "404": {
+              "$ref": "external/responses.yml#/responses/notFound"
+             },
+             "default": {
+              "schema": {
+               "$ref": "#/definitions/record"
+              }
+             }
+            }
+           },
+           "parameters": [
+            {
+             "$ref": "external/parameters.yml#/parameters/idParam"
+            },
+            {
+             "name": "bodyId",
+             "in": "body",
+             "schema": {
+              "$ref": "#/definitions/record"
+             }
+            }
+           ]
+          }
+         },
+         "definitions": {
+          "datedRecords": {
+           "type": "array",
+           "items": [
+            {
+             "type": "string",
+             "format": "date-time"
+            },
+            {
+             "$ref": "#/definitions/record"
+            }
+           ]
+          },
+          "datedTag": {
+           "allOf": [
+            {
+             "type": "string",
+             "format": "date"
+            },
+            {
+             "$ref": "#/definitions/tag"
+            }
+           ]
+          },
+          "datedTaggedRecords": {
+           "type": "array",
+           "items": [
+            {
+             "type": "string",
+             "format": "date-time"
+            },
+            {
+             "$ref": "#/definitions/record"
+            }
+           ],
+           "additionalItems": {
+            "$ref": "#/definitions/tag"
+           }
+          },
+          "named": {
+           "type": "string"
+          },
+          "namedAgain": {
+           "$ref": "#/definitions/named"
+          },
+          "namedThing": {
+           "type": "object",
+           "properties": {
+            "name": {
+             "$ref": "#/definitions/named"
+            }
+           }
+          },
+          "otherRecords": {
+           "type": "array",
+           "items": {
+            "$ref": "#/definitions/record"
+           }
+          },
+          "record": {
+           "type": "object",
+           "properties": {
+            "createdAt": {
+             "type": "string",
+             "format": "date-time"
+            }
+           }
+          },
+          "records": {
+           "type": "array",
+           "items": [
+            {
+             "$ref": "#/definitions/record"
+            }
+           ]
+          },
+          "tag": {
+           "type": "object",
+           "properties": {
+            "audit": {
+             "$ref": "external/definitions.yml#/definitions/record"
+            },
+            "id": {
+             "type": "integer",
+             "format": "int64"
+            },
+            "value": {
+             "type": "string"
+            }
+           }
+          },
+          "tags": {
+           "type": "object",
+           "additionalProperties": {
+            "$ref": "#/definitions/tag"
+           }
+          }
+         },
+         "parameters": {
+          "someParam": {
+           "name": "someParam",
+           "in": "body",
+           "schema": {
+            "$ref": "#/definitions/record"
+           }
+          }
+         },
+         "responses": {
+          "someResponse": {
+           "schema": {
+            "$ref": "#/definitions/record"
+           }
+          }
+         }
+        }`, string(bb))
+
+	// iterate again: this time all external schema $ref's should be reinlined
+	opts.Spec.reload()
+	_, err = importExternalReferences(&FlattenOpts{
+		Spec:     New(sp),
+		BasePath: bp,
+	})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	opts.Spec.reload()
+	for _, ref := range opts.Spec.references.schemas {
+		assert.True(t, ref.HasFragmentOnly)
+	}
+
+	// now try complete flatten
+	sp = loadOrFail(t, bp)
+	an := New(sp)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, RemoveUnused: true})
+	assert.NoError(t, err)
+
+	bbb, _ := json.MarshalIndent(an.spec, "", " ")
+	//t.Logf("%s", string(bbb))
+	assert.JSONEq(t, `{
+		"swagger": "2.0",
+         "info": {
+          "title": "reference analysis",
+          "version": "0.1.0"
+         },
+         "paths": {
+          "/other/place": {
+           "get": {
+            "description": "Used to see if a codegen can render all the possible parameter variations for a header param",
+            "tags": [
+             "testcgen"
+            ],
+            "summary": "many model variations",
+            "operationId": "modelOp",
+            "responses": {
+             "default": {
+              "description": "Generic Out"
+             }
+            }
+           }
+          },
+          "/some/where/{id}": {
+           "get": {
+            "parameters": [
+             {
+              "type": "integer",
+              "format": "int32",
+              "name": "limit",
+              "in": "query"
+             },
+             {
+              "type": "array",
+              "items": {
+               "type": "string"
+              },
+              "name": "other",
+              "in": "query"
+             },
+             {
+              "name": "body",
+              "in": "body",
+              "schema": {
+               "$ref": "#/definitions/record"
+              }
+             }
+            ],
+            "responses": {
+             "200": {
+              "schema": {
+               "$ref": "#/definitions/tag"
+              }
+             },
+             "404": {
+              "schema": {
+               "$ref": "#/definitions/error"
+              }
+             },
+             "default": {
+              "schema": {
+               "$ref": "#/definitions/record"
+              }
+             }
+            }
+           },
+           "parameters": [
+            {
+             "type": "integer",
+             "format": "int32",
+             "name": "id",
+             "in": "path"
+            },
+            {
+             "name": "bodyId",
+             "in": "body",
+             "schema": {
+              "$ref": "#/definitions/record"
+             }
+            }
+           ]
+          }
+         },
+         "definitions": {
+          "error": {
+           "type": "object",
+           "required": [
+            "id",
+            "message"
+           ],
+           "properties": {
+            "id": {
+             "type": "integer",
+             "format": "int64",
+             "readOnly": true
+            },
+            "message": {
+             "type": "string",
+             "readOnly": true
+            }
+           }
+          },
+          "named": {
+           "type": "string"
+          },
+          "record": {
+           "type": "object",
+           "properties": {
+            "createdAt": {
+             "type": "string",
+             "format": "date-time"
+            }
+           }
+          },
+          "tag": {
+           "type": "object",
+           "properties": {
+            "audit": {
+             "$ref": "#/definitions/record"
+            },
+            "id": {
+             "type": "integer",
+             "format": "int64"
+            },
+            "value": {
+             "type": "string"
+            }
+           }
+          }
+         }
+        }`, string(bbb))
 }
 
 func TestRewriteSchemaRef(t *testing.T) {
@@ -934,6 +1269,7 @@ func TestFlatten_oaigenFull(t *testing.T) {
 
 	var logCapture bytes.Buffer
 	log.SetOutput(&logCapture)
+	//Debug = true
 	err = Flatten(FlattenOpts{Spec: New(sp), BasePath: bp, Verbose: true, Minimal: false, RemoveUnused: false})
 	msg := logCapture.String()
 
@@ -941,6 +1277,9 @@ func TestFlatten_oaigenFull(t *testing.T) {
 		t.FailNow()
 		return
 	}
+
+	//bbb, _ := json.MarshalIndent(sp, "", " ")
+	//t.Logf("%s", string(bbb))
 
 	if !assert.Containsf(t, msg, "warning: duplicate flattened definition name resolved as aAOAIGen",
 		"Expected log message") {
@@ -992,15 +1331,24 @@ func TestFlatten_oaigenFull(t *testing.T) {
 	res = getDefinition(t, sp, "bB")
 	assert.JSONEqf(t, `{"type": "string", "format": "date-time"}`, res, "Expected a simple schema for response")
 
-	res = getDefinition(t, sp, "d")
+	res = getDefinition(t, sp, "bItems")
 	assert.JSONEqf(t, `{
 		   "type": "object",
 		   "properties": {
 		    "c": {
 		     "type": "integer"
 		    }
-		   }
+		   },
+		   "x-go-gen-location": "models"
 	}`, res, "Expected a simple schema for response")
+
+	res = getDefinition(t, sp, "b")
+	assert.JSONEqf(t, `{
+		   "type": "array",
+		   "items": {
+			   "$ref": "#/definitions/bItems"
+		   }
+	}`, res, "Expected a ref in response")
 
 	res = getDefinition(t, sp, "myBody")
 	assert.JSONEqf(t, `{
@@ -1176,15 +1524,24 @@ func TestFlatten_oaigenMinimal(t *testing.T) {
 	res = getDefinition(t, sp, "bB")
 	assert.JSONEqf(t, `{"type": "string", "format": "date-time"}`, res, "Expected a simple schema for response")
 
-	res = getDefinition(t, sp, "d")
+	res = getDefinition(t, sp, "bItems")
 	assert.JSONEqf(t, `{
 		   "type": "object",
 		   "properties": {
 		    "c": {
 		     "type": "integer"
 		    }
-		   }
+		   },
+		   "x-go-gen-location": "models"
 	}`, res, "Expected a simple schema for response")
+
+	res = getDefinition(t, sp, "b")
+	assert.JSONEqf(t, `{
+		   "type": "array",
+		   "items": {
+			   "$ref": "#/definitions/bItems"
+		   }
+	}`, res, "Expected a ref in response")
 
 	res = getDefinition(t, sp, "myBody")
 	assert.JSONEqf(t, `{
@@ -1793,7 +2150,6 @@ func TestFlatten_Issue_1614(t *testing.T) {
 	bbb, _ := json.Marshal(sp)
 	assert.NotContains(t, string(bbb), `#/responses/forbidden`)
 	assert.NotContains(t, string(bbb), `#/responses/empty`)
-	//t.Logf("%v", string(bbb))
 }
 
 func TestFlatten_Issue_1621(t *testing.T) {
@@ -1904,4 +2260,80 @@ func TestFlatten_1429(t *testing.T) {
 	an := New(sp)
 	err := Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, RemoveUnused: false})
 	assert.NoError(t, err)
+}
+
+func TestRebaseRef(t *testing.T) {
+	assert.Equal(t, "#/definitions/abc", rebaseRef("#/definitions/base", "#/definitions/abc"))
+	assert.Equal(t, "#/definitions/abc", rebaseRef("", "#/definitions/abc"))
+	assert.Equal(t, "#/definitions/abc", rebaseRef(".", "#/definitions/abc"))
+	assert.Equal(t, "otherfile#/definitions/abc", rebaseRef("file#/definitions/base", "otherfile#/definitions/abc"))
+	assert.Equal(t, "../otherfile#/definitions/abc", rebaseRef("../file#/definitions/base", "./otherfile#/definitions/abc"))
+	assert.Equal(t, "../otherfile#/definitions/abc", rebaseRef("../file#/definitions/base", "otherfile#/definitions/abc"))
+	assert.Equal(t, "local/remote/otherfile#/definitions/abc", rebaseRef("local/file#/definitions/base", "remote/otherfile#/definitions/abc"))
+	assert.Equal(t, "local/remote/otherfile.yaml", rebaseRef("local/file.yaml", "remote/otherfile.yaml"))
+
+	assert.Equal(t, "file#/definitions/abc", rebaseRef("file#/definitions/base", "#/definitions/abc"))
+
+	// with remote
+	assert.Equal(t, "https://example.com/base/definitions/abc", rebaseRef("https://example.com/base", "https://example.com/base/definitions/abc"))
+	assert.Equal(t, "https://example.com/base/definitions/abc", rebaseRef("https://example.com/base", "#/definitions/abc"))
+	assert.Equal(t, "https://example.com/base/dir/definitions/abc", rebaseRef("https://example.com/base", "#/dir/definitions/abc"))
+	assert.Equal(t, "https://example.com/base/dir/definitions/abc", rebaseRef("https://example.com/base/spec.yaml", "dir/definitions/abc"))
+	assert.Equal(t, "https://example.com/base/dir/definitions/abc", rebaseRef("https://example.com/base/", "dir/definitions/abc"))
+	assert.Equal(t, "https://example.com/dir/definitions/abc", rebaseRef("https://example.com/base", "dir/definitions/abc"))
+}
+
+func TestFlatten_1851(t *testing.T) {
+	// nested / remote $ref in response / param schemas
+	// issue go-swagger/go-swagger#1851
+	bp := filepath.Join("fixtures", "bugs", "1851", "fixture-1851.yaml")
+	sp := loadOrFail(t, bp)
+
+	an := New(sp)
+	err := Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, RemoveUnused: false})
+	assert.NoError(t, err)
+	var jazon []byte
+
+	//bbb, _ := json.MarshalIndent(an.spec, "", " ")
+	//t.Logf("%s", string(bbb))
+	serverDefinition, ok := an.spec.Definitions["server"]
+	assert.True(t, ok)
+	serverStatusDefinition, ok := an.spec.Definitions["serverStatus"]
+	assert.True(t, ok)
+	serverStatusProperty, ok := serverDefinition.Properties["Status"]
+	assert.True(t, ok)
+	jazon, _ = json.Marshal(serverStatusProperty)
+	assert.JSONEq(t, `{"$ref": "#/definitions/serverStatus"}`, string(jazon))
+	jazon, _ = json.Marshal(serverStatusDefinition)
+	assert.JSONEq(t, `{
+         "type": "string",
+         "enum": [
+          "OK",
+          "Not OK"
+         ]
+	 }`, string(jazon))
+
+	// additional test case: this one used to work
+	bp = filepath.Join("fixtures", "bugs", "1851", "fixture-1851-2.yaml")
+	sp = loadOrFail(t, bp)
+
+	an = New(sp)
+	err = Flatten(FlattenOpts{Spec: an, BasePath: bp, Verbose: true, Minimal: true, RemoveUnused: false})
+	assert.NoError(t, err)
+	serverDefinition, ok = an.spec.Definitions["Server"]
+	assert.True(t, ok)
+	serverStatusDefinition, ok = an.spec.Definitions["ServerStatus"]
+	assert.True(t, ok)
+	serverStatusProperty, ok = serverDefinition.Properties["Status"]
+	assert.True(t, ok)
+	jazon, _ = json.Marshal(serverStatusProperty)
+	assert.JSONEq(t, `{"$ref": "#/definitions/ServerStatus"}`, string(jazon))
+	jazon, _ = json.Marshal(serverStatusDefinition)
+	assert.JSONEq(t, `{
+         "type": "string",
+         "enum": [
+          "OK",
+          "Not OK"
+         ]
+	 }`, string(jazon))
 }


### PR DESCRIPTION
Flatten now resolves remote $ref iteratively, without expanding.

This allows for keeping definitions unexpanded and reused by referers positioned at different nesting levels.

Contributes go-swagger/go-swagger#1851

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>