### PR TITLE
fix(mixin): added support for merging top-level info

### DIFF
--- a/fixtures/empty-props.yml
+++ b/fixtures/empty-props.yml
@@ -1,0 +1,27 @@
+---
+swagger: '2.0'
+info:
+  title: ""
+  contact:
+    name: ""
+  license:
+    name: ""
+schemes:
+  - http
+basePath: ""
+consumes:
+  - application/json
+produces:
+  - application/json
+externalDocumentation:
+  description: ""
+x-custom: zorg
+x-conflict: buzz
+paths:
+  /common:
+    get:
+      operationId: commonGet
+      summary: here to test path collisons
+      responses:
+        '200':
+          description: OK

--- a/fixtures/swagger-props.yml
+++ b/fixtures/swagger-props.yml
@@ -1,0 +1,30 @@
+---
+swagger: '2.0'
+host: www.example.com
+basePath: /merged
+info:
+  title: "Merged title"
+  description: "Merged description"
+  termsOfService: "Merged terms"
+  version: "x"
+  contact:
+    name: "merged contact"
+    URL: "https://www.example.com/contact"
+    Email: "contact@example.com"
+  license:
+    name: "merged license"
+    URL: "https://www.example.com/license"
+  x-custom-info: custom
+externalDocumentation:
+  description: "merge doc"
+  URL: "https://www.example.com/doc"
+x-merger: value
+x-conflict: buzz
+paths:
+  /merged:
+    get:
+      operationId: mergedGet
+      summary: here to test merged path
+      responses:
+        '200':
+          description: OK

--- a/mixin_test.go
+++ b/mixin_test.go
@@ -15,6 +15,7 @@
 package analysis
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -26,6 +27,8 @@ const (
 	emptyPathsFile = "fixtures/empty-paths.json"
 	securityFile   = "fixtures/securitydef.yml"
 	otherMixin     = "fixtures/other-mixin.yml"
+	emptyProps     = "fixtures/empty-props.yml"
+	swaggerProps   = "fixtures/swagger-props.yml"
 )
 
 func TestMixin(t *testing.T) {
@@ -133,4 +136,21 @@ func TestMixinFromNilPath(t *testing.T) {
 	}
 	//bbb, _ := json.MarshalIndent(primary.Paths.Paths, "", " ")
 	//t.Log(string(bbb))
+}
+
+func TestMixinSwaggerProps(t *testing.T) {
+	primary, err := loadSpec(emptyProps)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", emptyProps, err)
+	}
+	mixin, err := loadSpec(swaggerProps)
+	if err != nil {
+		t.Fatalf("Could not load '%v': %v\n", swaggerProps, err)
+	}
+	collisions := Mixin(primary, mixin)
+	if len(collisions) != 1 {
+		t.Errorf("TestMixin: Expected 1 collisions, got %v\n%v", len(collisions), collisions)
+	}
+	bbb, _ := json.MarshalIndent(primary, "", " ")
+	t.Log(string(bbb))
 }


### PR DESCRIPTION
added support for merging top-level info and vendor extensions at top level and in info struct

Contributes go-swagger/go-swagger#1886
Contributes go-swagger/go-swagger#1965

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>