### PR TITLE
schema.go: Fix bad nil guard

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -218,7 +218,7 @@ func (a *AnalyzedSchema) initializeFlags() {
 		(a.schema.Items.Schema != nil || len(a.schema.Items.Schemas) > 0)
 
 	a.hasAdditionalProps = a.schema.AdditionalProperties != nil &&
-		(a.schema.AdditionalProperties != nil || a.schema.AdditionalProperties.Allows)
+		(a.schema.AdditionalProperties.Schema != nil || a.schema.AdditionalProperties.Allows)
 
 	a.hasAdditionalItems = a.schema.AdditionalItems != nil &&
 		(a.schema.AdditionalItems.Schema != nil || a.schema.AdditionalItems.Allows)


### PR DESCRIPTION
The following was found by dgryski's [semgrep-go](https://github.com/dgryski/semgrep-go) rule collection:
```
schema.go
severity:error rule:github.com.dgryski.semgrep-go.bad-nil-guard: Bad nil guard
221:		(a.schema.AdditionalProperties != nil || a.schema.AdditionalProperties.Allows)
```
Signed-off-by: Karsten Weiss <knweiss@gmail.com>