### PR TITLE
fixed test coverage measurement issue with multiple packages 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,52 @@
-after_success:
-- bash <(curl -s https://codecov.io/bash)
+language: go
 go:
-- 1.14.x
 - 1.x
 arch:
-  - amd64
-  - ppc64le
+- amd64
+- arm64
+- ppc64le
 install:
-- go get -u gotest.tools/gotestsum
-language: go
+- go get gotest.tools/gotestsum
+jobs:
+  include:
+  # include older golang
+  - go: 1.15.x
+    arch:
+    - amd64
+    script:
+    - gotestsum -f short-verbose -- -timeout=10m ./...
+
+  # include osx, but only for latest go version - skip testing for race
+  - go: 1.x
+    os:
+    - osx
+    script:
+    - gotestsum -f short-verbose -- -timeout=10m ./...
+
+  # include linting check job, but only for latest go version and amd64 arch
+  - go: 1.x
+    arch: amd64
+    install:
+      go get github.com/golangci/golangci-lint/cmd/golangci-lint
+    script:
+    - golangci-lint run --new-from-rev master
+
+  # include race test, but only for latest go version and amd64 arch
+  - go: 1.x
+    arch: amd64
+    script:
+    - gotestsum -f short-verbose -- -timeout=20m -race ./...
+ 
+  # include long test and test coverage collection, but only for latest go version and amd64 arch
+  - go: 1.x
+    arch: amd64
+    script:
+    - gotestsum -f short-verbose -- -timeout=20m -covermode=atomic -coverprofile=coverage.txt -coverpkg "./..." -args -enable-long ./...
+    after_success:
+    - bash <(curl -s https://codecov.io/bash)
+
 notifications:
   slack:
     secure: Sf7kZf7ZGbnwWUMpffHwMu5A0cHkLK2MYY32LNTPj4+/3qC3Ghl7+9v4TSLOqOlCwdRNjOGblAq7s+GDJed6/xgRQl1JtCi1klzZNrYX4q01pgTPvvGcwbBkIYgeMaPeIRcK9OZnud7sRXdttozgTOpytps2U6Js32ip7uj5mHSg2ub0FwoSJwlS6dbezZ8+eDhoha0F/guY99BEwx8Bd+zROrT2TFGsSGOFGN6wFc7moCqTHO/YkWib13a2QNXqOxCCVBy/lt76Wp+JkeFppjHlzs/2lP3EAk13RIUAaesdEUHvIHrzCyNJEd3/+KO2DzsWOYfpktd+KBCvgaYOsoo7ubdT3IROeAegZdCgo/6xgCEsmFc9ZcqCfN5yNx2A+BZ2Vwmpws+bQ1E1+B5HDzzaiLcYfG4X2O210QVGVDLWsv1jqD+uPYeHY2WRfh5ZsIUFvaqgUEnwHwrK44/8REAhQavt1QAj5uJpsRd7CkRVPWRNK+yIky+wgbVUFEchRNmS55E7QWf+W4+4QZkQi7vUTMc9nbTUu2Es9NfvfudOpM2wZbn98fjpb/qq/nRv6Bk+ca+7XD5/IgNLMbWp2ouDdzbiHLCOfDUiHiDJhLfFZx9Bwo7ZwfzeOlbrQX66bx7xRKYmOe4DLrXhNcpbsMa8qbfxlZRCmYbubB/Y8h4=
 script:
-- gotestsum -f short-verbose -- -timeout=20m -coverprofile=coverage.txt -coverpkg `echo $(go list ./...|grep -vE 'analysis$')|sed -E '1,$s/\s/,/'` -args -enable-long ./...
-- gotestsum -f short-verbose -- -race -timeout=20m  ./...
+- gotestsum -f short-verbose -- -timeout=10m ./...

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Slack Status](https://slackin.goswagger.io/badge.svg)](https://slackin.goswagger.io)
 [![license](http://img.shields.io/badge/license-Apache%20v2-orange.svg)](https://raw.githubusercontent.com/go-openapi/analysis/master/LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-openapi/analysis.svg)](https://pkg.go.dev/github.com/go-openapi/analysis)
-[![GolangCI](https://golangci.com/badges/github.com/go-openapi/analysis.svg)](https://golangci.com)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-openapi/analysis)](https://goreportcard.com/report/github.com/go-openapi/analysis)
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build: off
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.15
+stack: go 1.16
 
 test_script:
   - go test -v -timeout 20m ./...

--- a/internal/antest/helpers.go
+++ b/internal/antest/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/go-openapi/spec"
@@ -11,7 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
+var oncePathLoader sync.Once
+
+func initPathLoader() {
 	spec.PathLoader = func(path string) (json.RawMessage, error) {
 		ext := filepath.Ext(path)
 		if ext == ".yml" || ext == ".yaml" {
@@ -29,6 +32,8 @@ func init() {
 
 // LoadSpec loads a json a yaml spec
 func LoadSpec(path string) (*spec.Swagger, error) {
+	oncePathLoader.Do(initPathLoader)
+
 	data, err := swag.YAMLDoc(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* bumped go versions in CI
* reduced the travis CI matrix to run longer tests only on one arch and go version
* enriched the travis CI matrix with osx and arm64 runs
* removed golangCI badge

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>