### PR TITLE
Remove spurious literal tab characters from YAML fixture

### DIFF
--- a/analysis_test/spec_test.go
+++ b/analysis_test/spec_test.go
@@ -138,7 +138,7 @@ func makeFileSpec(t testing.TB) (string, func()) {
 
 func fixtureIssue66() []byte {
 	return []byte(`
-	x-google-endpoints:
+x-google-endpoints:
   - name: bravo-api.endpoints.dev-srplatform.cloud.goog
     allowCors: true
 host: bravo-api.endpoints.dev-srplatform.cloud.goog
@@ -232,5 +232,5 @@ securityDefinitions:
     x-google-issuer: "http://okta.example.com"
     x-google-jwks_uri: "http://okta.example.com/v1/keys"
     x-google-audiences: "http://api.example.com"
-	`)
+`)
 }


### PR DESCRIPTION
This is causing parse errors such as:

  yaml: line 2: found character that cannot start any token

and

  yaml: line 96: found character that cannot start any token

Signed-off-by: Guillem Jover <gjover@sipwise.com>