### PR TITLE
Ignore varnamelen linter in ci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,3 +50,4 @@ linters:
     - ifshort
     - forbidigo
     - cyclop
+    - varnamelen


### PR DESCRIPTION
Goal is to make link on master branch pass.