### PR TITLE
fix(flatten): remove unused acts recursively

### DIFF
--- a/fixtures/bugs/2657/schema-flattened.yaml
+++ b/fixtures/bugs/2657/schema-flattened.yaml
@@ -1,0 +1,19 @@
+consumes:
+    - application/json
+produces:
+    - application/json
+schemes:
+    - http
+    - https
+swagger: "2.0"
+info:
+    title: Sample API.
+    version: 1.0.0
+paths:
+    /hello:
+        get:
+            description: Hello
+            operationId: hello
+            responses:
+                "200":
+                    description: success

--- a/fixtures/bugs/2657/schema.json
+++ b/fixtures/bugs/2657/schema.json
@@ -1,0 +1,48 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "title": "Sample API.",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "description": "Hello",
+        "operationId": "hello",
+        "responses": {
+          "200": {
+            "description": "success"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Author": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Book": {
+      "type": "object",
+      "properties": {
+        "author": {
+          "$ref": "#/definitions/Author"
+        }
+      }
+    }
+  }
+}

--- a/fixtures/expected/external-references-2.json
+++ b/fixtures/expected/external-references-2.json
@@ -102,9 +102,6 @@
      }
     }
    },
-   "named": {
-    "type": "string"
-   },
    "record": {
     "type": "object",
     "properties": {

--- a/flatten.go
+++ b/flatten.go
@@ -267,6 +267,12 @@ func nameInlinedSchemas(opts *FlattenOpts) error {
 }
 
 func removeUnused(opts *FlattenOpts) {
+	for removeUnusedSinglePass(opts) {
+		// continue until no unused definition remains
+	}
+}
+
+func removeUnusedSinglePass(opts *FlattenOpts) (hasRemoved bool) {
 	expected := make(map[string]struct{})
 	for k := range opts.Swagger().Definitions {
 		expected[path.Join(definitionsPath, jsonpointer.Escape(k))] = struct{}{}
@@ -277,6 +283,7 @@ func removeUnused(opts *FlattenOpts) {
 	}
 
 	for k := range expected {
+		hasRemoved = true
 		debugLog("removing unused definition %s", path.Base(k))
 		if opts.Verbose {
 			log.Printf("info: removing unused definition: %s", path.Base(k))
@@ -285,6 +292,8 @@ func removeUnused(opts *FlattenOpts) {
 	}
 
 	opts.Spec.reload() // re-analyze
+
+	return hasRemoved
 }
 
 func importKnownRef(entry sortref.RefRevIdx, refStr, newName string, opts *FlattenOpts) error {

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -145,7 +145,7 @@ func TestFlatten_ImportExternalReferences(t *testing.T) {
 		require.True(t, ref.HasFragmentOnly)
 	}
 
-	// now try complete flatten
+	// now try complete flatten, with unused definitions removed
 	sp = antest.LoadOrFail(t, bp)
 	an := New(sp)
 
@@ -1381,6 +1381,23 @@ func TestFlatten_1898(t *testing.T) {
 	require.Len(t, def.Properties, 2)
 	require.Contains(t, def.Properties, "error")
 	require.Contains(t, def.Properties, "result")
+}
+
+func TestFlatten_RemoveUnused_2657(t *testing.T) {
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	bp := filepath.Join("fixtures", "bugs", "2657", "schema.json")
+	sp := antest.LoadOrFail(t, bp)
+	an := New(sp)
+
+	require.NoError(t, Flatten(FlattenOpts{
+		Spec: an, BasePath: bp, Verbose: true,
+		Minimal:      true,
+		Expand:       false,
+		RemoveUnused: true,
+	}))
+	require.Empty(t, sp.Definitions)
 }
 
 func getDefinition(t testing.TB, sp *spec.Swagger, key string) string {


### PR DESCRIPTION
Whenever unused definitions are removed, some new definitions may appear as unused. This PR goes does this rabbit hole to delete all unused definitions until no unused candidate shows up.

* contributes go-swagger/go-swagger#2657