### PR TITLE
test(flatten): asserts that the ExpandSpec fix in spec works

### DIFF
--- a/fixtures/bugs/2743/not-working/minimal.yaml
+++ b/fixtures/bugs/2743/not-working/minimal.yaml
@@ -1,0 +1,7 @@
+swagger: '2.0'
+info:
+  version: 0.0.0
+  title: Simple API
+paths:
+  /bar:
+    $ref: 'swagger/paths/bar.yml'

--- a/fixtures/bugs/2743/not-working/spec.yaml
+++ b/fixtures/bugs/2743/not-working/spec.yaml
@@ -1,0 +1,11 @@
+swagger: '2.0'
+info:
+  version: 0.0.0
+  title: Simple API
+paths:
+  /foo:
+    $ref: 'swagger/paths/foo.yml'
+  /bar:
+    $ref: 'swagger/paths/bar.yml'
+  /nested:
+    $ref: 'swagger/paths/nested.yml#/response'

--- a/fixtures/bugs/2743/not-working/swagger/definitions.yml
+++ b/fixtures/bugs/2743/not-working/swagger/definitions.yml
@@ -1,0 +1,9 @@
+ErrorPayload:
+  title: Error Payload
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: './items.yml#/ErrorDetailsItem'

--- a/fixtures/bugs/2743/not-working/swagger/items.yml
+++ b/fixtures/bugs/2743/not-working/swagger/items.yml
@@ -1,0 +1,15 @@
+ErrorDetailsItem:
+  title: Error details item
+  description: Represents an item of the list of details of an error.
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+    code:
+      type: string
+    details:
+      type: array
+      items:
+        type: string

--- a/fixtures/bugs/2743/not-working/swagger/paths/bar.yml
+++ b/fixtures/bugs/2743/not-working/swagger/paths/bar.yml
@@ -1,0 +1,8 @@
+get:
+  responses:
+    200:
+      description: OK
+      schema:
+        type: array
+        items:
+          $ref: '../user/index.yml#/User' ## this doesn't work

--- a/fixtures/bugs/2743/not-working/swagger/paths/foo.yml
+++ b/fixtures/bugs/2743/not-working/swagger/paths/foo.yml
@@ -1,0 +1,8 @@
+get:
+  responses:
+    200:
+      description: OK
+    500:
+      description: OK
+      schema:
+        $ref: '../definitions.yml#/ErrorPayload'

--- a/fixtures/bugs/2743/not-working/swagger/paths/index.yml
+++ b/fixtures/bugs/2743/not-working/swagger/paths/index.yml
@@ -1,0 +1,6 @@
+/foo:
+  $ref: ./foo.yml
+/bar:
+  $ref: ./bar.yml
+/nested:
+  $ref: ./nested.yml#/response

--- a/fixtures/bugs/2743/not-working/swagger/paths/nested.yml
+++ b/fixtures/bugs/2743/not-working/swagger/paths/nested.yml
@@ -1,0 +1,14 @@
+response:
+  get:
+    responses:
+      200:
+        description: OK
+        schema:
+          $ref: '#/definitions/SameFileReference'
+
+definitions:
+  SameFileReference:
+    type: object
+    properties:
+      name:
+        type: string

--- a/fixtures/bugs/2743/not-working/swagger/user/index.yml
+++ b/fixtures/bugs/2743/not-working/swagger/user/index.yml
@@ -1,0 +1,2 @@
+User:
+  $ref: './model.yml'

--- a/fixtures/bugs/2743/not-working/swagger/user/model.yml
+++ b/fixtures/bugs/2743/not-working/swagger/user/model.yml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  name:
+    type: string

--- a/fixtures/bugs/2743/working/spec.yaml
+++ b/fixtures/bugs/2743/working/spec.yaml
@@ -1,0 +1,11 @@
+swagger: '2.0'
+info:
+  version: 0.0.0
+  title: Simple API
+paths:
+  /foo:
+    $ref: 'swagger/paths/foo.yml'
+  /bar:
+    $ref: 'swagger/paths/bar.yml'
+  /nested:
+    $ref: 'swagger/paths/nested.yml#/response'

--- a/fixtures/bugs/2743/working/swagger/definitions.yml
+++ b/fixtures/bugs/2743/working/swagger/definitions.yml
@@ -1,0 +1,9 @@
+ErrorPayload:
+  title: Error Payload
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: './items.yml#/ErrorDetailsItem'

--- a/fixtures/bugs/2743/working/swagger/items.yml
+++ b/fixtures/bugs/2743/working/swagger/items.yml
@@ -1,0 +1,15 @@
+ErrorDetailsItem:
+  title: Error details item
+  description: Represents an item of the list of details of an error.
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+    code:
+      type: string
+    details:
+      type: array
+      items:
+        type: string

--- a/fixtures/bugs/2743/working/swagger/paths/bar.yml
+++ b/fixtures/bugs/2743/working/swagger/paths/bar.yml
@@ -1,0 +1,8 @@
+get:
+  responses:
+    200:
+      description: OK
+      schema:
+        type: array
+        items:
+          $ref: './swagger/user/index.yml#/User' ## this works

--- a/fixtures/bugs/2743/working/swagger/paths/foo.yml
+++ b/fixtures/bugs/2743/working/swagger/paths/foo.yml
@@ -1,0 +1,8 @@
+get:
+  responses:
+    200:
+      description: OK
+    500:
+      description: OK
+      schema:
+        $ref: '../definitions.yml#/ErrorPayload'

--- a/fixtures/bugs/2743/working/swagger/paths/index.yml
+++ b/fixtures/bugs/2743/working/swagger/paths/index.yml
@@ -1,0 +1,6 @@
+/foo:
+  $ref: ./foo.yml
+/bar:
+  $ref: ./bar.yml
+/nested:
+  $ref: ./nested.yml#/response

--- a/fixtures/bugs/2743/working/swagger/paths/nested.yml
+++ b/fixtures/bugs/2743/working/swagger/paths/nested.yml
@@ -1,0 +1,14 @@
+response:
+  get:
+    responses:
+      200:
+        description: OK
+        schema:
+          $ref: '#/definitions/SameFileReference'
+
+definitions:
+  SameFileReference:
+    type: object
+    properties:
+      name:
+        type: string

--- a/fixtures/bugs/2743/working/swagger/user/index.yml
+++ b/fixtures/bugs/2743/working/swagger/user/index.yml
@@ -1,0 +1,2 @@
+User:
+  $ref: './model.yml'

--- a/fixtures/bugs/2743/working/swagger/user/model.yml
+++ b/fixtures/bugs/2743/working/swagger/user/model.yml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  name:
+    type: string

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -1400,6 +1400,35 @@ func TestFlatten_RemoveUnused_2657(t *testing.T) {
 	require.Empty(t, sp.Definitions)
 }
 
+func TestFlatten_Relative_2743(t *testing.T) {
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	t.Run("used to work, but should NOT", func(t *testing.T) {
+		bp := filepath.Join("fixtures", "bugs", "2743", "working", "spec.yaml")
+		sp := antest.LoadOrFail(t, bp)
+		an := New(sp)
+
+		require.Error(t, Flatten(FlattenOpts{
+			Spec: an, BasePath: bp, Verbose: true,
+			Minimal: true,
+			Expand:  false,
+		}))
+	})
+
+	t.Run("used not to, but should work", func(t *testing.T) {
+		bp := filepath.Join("fixtures", "bugs", "2743", "not-working", "spec.yaml")
+		sp := antest.LoadOrFail(t, bp)
+		an := New(sp)
+
+		require.NoError(t, Flatten(FlattenOpts{
+			Spec: an, BasePath: bp, Verbose: true,
+			Minimal: true,
+			Expand:  false,
+		}))
+	})
+}
+
 func getDefinition(t testing.TB, sp *spec.Swagger, key string) string {
 	d, ok := sp.Definitions[key]
 	require.Truef(t, ok, "Expected definition for %s", key)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-openapi/analysis
 
 require (
 	github.com/go-openapi/jsonpointer v0.20.2
-	github.com/go-openapi/spec v0.20.13
+	github.com/go-openapi/spec v0.20.14
 	github.com/go-openapi/strfmt v0.21.10
 	github.com/go-openapi/swag v0.22.6
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/go-openapi/jsonpointer v0.20.2 h1:mQc3nmndL8ZBzStEo3JYF8wzmeWffDH4VbX
 github.com/go-openapi/jsonpointer v0.20.2/go.mod h1:bHen+N0u1KEO3YlmqOjTT9Adn1RfD91Ar825/PuiRVs=
 github.com/go-openapi/jsonreference v0.20.4 h1:bKlDxQxQJgwpUSgOENiMPzCTBVuc7vTdXSSgNeAhojU=
 github.com/go-openapi/jsonreference v0.20.4/go.mod h1:5pZJyJP2MnYCpoeoMAql78cCHauHj0V9Lhc506VOpw4=
-github.com/go-openapi/spec v0.20.13 h1:XJDIN+dLH6vqXgafnl5SUIMnzaChQ6QTo0/UPMbkIaE=
-github.com/go-openapi/spec v0.20.13/go.mod h1:8EOhTpBoFiask8rrgwbLC3zmJfz4zsCUueRuPM6GNkw=
+github.com/go-openapi/spec v0.20.14 h1:7CBlRnw+mtjFGlPDRZmAMnq35cRzI91xj03HVyUi/Do=
+github.com/go-openapi/spec v0.20.14/go.mod h1:8EOhTpBoFiask8rrgwbLC3zmJfz4zsCUueRuPM6GNkw=
 github.com/go-openapi/strfmt v0.21.10 h1:JIsly3KXZB/Qf4UzvzJpg4OELH/0ASDQsyk//TTBDDk=
 github.com/go-openapi/strfmt v0.21.10/go.mod h1:vNDMwbilnl7xKiO/Ve/8H8Bb2JIInBnH+lqiw6QWgis=
 github.com/go-openapi/swag v0.22.6 h1:dnqg1XfHXL9aBxSbktBqFR5CxVyVI+7fYWhAf1JOeTw=


### PR DESCRIPTION
This reproduces the $ref issue with relative paths in sibling folders in responses (same applies to parameters, but not schemas).

Added a test to verify that:
* (i) the invalid path that used to work no longer does
* (ii) the valid path that used not to work now does

* contributes go-swagger/go-swagger#2743