### PR TITLE
Relinting (2)

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -681,7 +681,7 @@ func (s *Spec) paramsAsMap(parameters []spec.Parameter, res map[string]spec.Para
 
 		obj, _, err := pr.Ref.GetPointer().Get(s.spec)
 		if err != nil {
-			if callmeOnError(param, fmt.Errorf("invalid reference: %q", pr.Ref.String())) {
+			if callmeOnError(param, ErrInvalidRef(pr.Ref.String())) {
 				continue
 			}
 
@@ -690,7 +690,7 @@ func (s *Spec) paramsAsMap(parameters []spec.Parameter, res map[string]spec.Para
 
 		objAsParam, ok := obj.(spec.Parameter)
 		if !ok {
-			if callmeOnError(param, fmt.Errorf("resolved reference is not a parameter: %q", pr.Ref.String())) {
+			if callmeOnError(param, ErrInvalidParameterRef(pr.Ref.String())) {
 				continue
 			}
 

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/analysis/internal/antest"
@@ -426,8 +427,8 @@ func TestAnalyzer_ParamsAsMapWithCallback(t *testing.T) {
 		return true // Continue
 	})
 
-	assert.Contains(t, e, `resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"`)
-	assert.Contains(t, e, `invalid reference: "#/definitions/sample_info/properties/sids"`)
+	assert.Contains(t, strings.Join(e, ","), `resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"`)
+	assert.Contains(t, strings.Join(e, ","), `invalid reference: "#/definitions/sample_info/properties/sids"`)
 
 	// bail out callback
 	m = make(map[string]spec.Parameter)
@@ -533,8 +534,8 @@ func TestAnalyzer_SafeParamsFor(t *testing.T) {
 		require.Fail(t, "There should be no safe parameter in this testcase")
 	}
 
-	assert.Contains(t, e, `resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"`)
-	assert.Contains(t, e, `invalid reference: "#/definitions/sample_info/properties/sids"`)
+	assert.Contains(t, strings.Join(e, ","), `resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"`)
+	assert.Contains(t, strings.Join(e, ","), `invalid reference: "#/definitions/sample_info/properties/sids"`)
 }
 
 func TestAnalyzer_ParamsFor(t *testing.T) {
@@ -581,8 +582,8 @@ func TestAnalyzer_SafeParametersFor(t *testing.T) {
 		require.Fail(t, "There should be no safe parameter in this testcase")
 	}
 
-	assert.Contains(t, e, `resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"`)
-	assert.Contains(t, e, `invalid reference: "#/definitions/sample_info/properties/sids"`)
+	assert.Contains(t, strings.Join(e, ","), `resolved reference is not a parameter: "#/definitions/sample_info/properties/sid"`)
+	assert.Contains(t, strings.Join(e, ","), `invalid reference: "#/definitions/sample_info/properties/sids"`)
 }
 
 func TestAnalyzer_ParametersFor(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,53 @@
+package analysis
+
+import (
+	"errors"
+	"fmt"
+)
+
+type analysisError string
+
+const (
+	ErrAnalysis analysisError = "analysis error"
+	ErrNoSchema analysisError = "no schema to analyze"
+)
+
+func (e analysisError) Error() string {
+	return string(e)
+}
+
+func ErrAtKey(key string, err error) error {
+	return errors.Join(
+		fmt.Errorf("key %s: %w", key, err),
+		ErrAnalysis,
+	)
+}
+
+func ErrInvalidRef(key string) error {
+	return fmt.Errorf("invalid reference: %q: %w", key, ErrAnalysis)
+}
+
+func ErrInvalidParameterRef(key string) error {
+	return fmt.Errorf("resolved reference is not a parameter: %q: %w", key, ErrAnalysis)
+}
+
+func ErrResolveSchema(err error) error {
+	return errors.Join(
+		fmt.Errorf("could not resolve schema: %w", err),
+		ErrAnalysis,
+	)
+}
+
+func ErrRewriteRef(key string, target any, err error) error {
+	return errors.Join(
+		fmt.Errorf("failed to rewrite ref for key %q at %v: %w", key, target, err),
+		ErrAnalysis,
+	)
+}
+
+func ErrInlineDefinition(key string, err error) error {
+	return errors.Join(
+		fmt.Errorf("error while creating definition %q from inline schema: %w", key, err),
+		ErrAnalysis,
+	)
+}

--- a/flatten.go
+++ b/flatten.go
@@ -15,7 +15,6 @@
 package analysis
 
 import (
-	"fmt"
 	"log"
 	"path"
 	"sort"
@@ -251,7 +250,7 @@ func nameInlinedSchemas(opts *FlattenOpts) error {
 
 		asch, err := Schema(SchemaOpts{Schema: sch.Schema, Root: opts.Swagger(), BasePath: opts.BasePath})
 		if err != nil {
-			return fmt.Errorf("schema analysis [%s]: %w", key, err)
+			return ErrAtKey(key, err)
 		}
 
 		if asch.isAnalyzedAsComplex() { // move complex schemas to definitions
@@ -320,7 +319,7 @@ func importNewRef(entry sortref.RefRevIdx, refStr string, opts *FlattenOpts) err
 
 	sch, err := spec.ResolveRefWithBase(opts.Swagger(), &entry.Ref, opts.ExpandOpts(false))
 	if err != nil {
-		return fmt.Errorf("could not resolve schema: %w", err)
+		return ErrResolveSchema(err)
 	}
 
 	// at this stage only $ref analysis matters
@@ -335,7 +334,7 @@ func importNewRef(entry sortref.RefRevIdx, refStr string, opts *FlattenOpts) err
 	// now rewrite those refs with rebase
 	for key, ref := range partialAnalyzer.references.allRefs {
 		if err := replace.UpdateRef(sch, key, spec.MustCreateRef(normalize.RebaseRef(entry.Ref.String(), ref.String()))); err != nil {
-			return fmt.Errorf("failed to rewrite ref for key %q at %s: %w", key, entry.Ref.String(), err)
+			return ErrRewriteRef(key, entry.Ref.String(), err)
 		}
 	}
 
@@ -429,7 +428,7 @@ func importExternalReferences(opts *FlattenOpts) (bool, error) {
 			ref := spec.MustCreateRef(r.path)
 			sch, err := spec.ResolveRefWithBase(opts.Swagger(), &ref, opts.ExpandOpts(false))
 			if err != nil {
-				return false, fmt.Errorf("could not resolve schema: %w", err)
+				return false, ErrResolveSchema(err)
 			}
 
 			r.schema = sch
@@ -666,7 +665,7 @@ func namePointers(opts *FlattenOpts) error {
 
 		result, err := replace.DeepestRef(opts.Swagger(), opts.ExpandOpts(false), ref)
 		if err != nil {
-			return fmt.Errorf("at %s, %w", k, err)
+			return ErrAtKey(k, err)
 		}
 
 		replacingRef := result.Ref
@@ -697,7 +696,7 @@ func namePointers(opts *FlattenOpts) error {
 		// update current replacement, which may have been updated by previous changes of deeper elements
 		result, erd := replace.DeepestRef(opts.Swagger(), opts.ExpandOpts(false), v.Ref)
 		if erd != nil {
-			return fmt.Errorf("at %s, %w", key, erd)
+			return ErrAtKey(key, erd)
 		}
 
 		if opts.flattenContext != nil {
@@ -743,7 +742,7 @@ func flattenAnonPointer(key string, v SchemaRef, refsToReplace map[string]Schema
 	// qualify the expanded schema
 	asch, ers := Schema(SchemaOpts{Schema: v.Schema, Root: opts.Swagger(), BasePath: opts.BasePath})
 	if ers != nil {
-		return fmt.Errorf("schema analysis [%s]: %w", key, ers)
+		return ErrAtKey(key, ers)
 	}
 	callers := make([]string, 0, allocMediumMap)
 
@@ -753,7 +752,7 @@ func flattenAnonPointer(key string, v SchemaRef, refsToReplace map[string]Schema
 	for k, w := range an.references.allRefs {
 		r, err := replace.DeepestRef(opts.Swagger(), opts.ExpandOpts(false), w)
 		if err != nil {
-			return fmt.Errorf("at %s, %w", key, err)
+			return ErrAtKey(key, err)
 		}
 
 		if opts.flattenContext != nil {

--- a/flatten_name.go
+++ b/flatten_name.go
@@ -43,7 +43,7 @@ func (isn *InlineSchemaNamer) Name(key string, schema *spec.Schema, aschema *Ana
 		debugLog("rewriting schema to ref: key=%s with new name: %s", key, newName)
 		if err := replace.RewriteSchemaToRef(isn.Spec, key,
 			spec.MustCreateRef(path.Join(definitionsPath, newName))); err != nil {
-			return fmt.Errorf("error while creating definition %q from inline schema: %w", newName, err)
+			return ErrInlineDefinition(newName, err)
 		}
 
 		// rewrite any dependent $ref pointing to this place,
@@ -54,7 +54,7 @@ func (isn *InlineSchemaNamer) Name(key string, schema *spec.Schema, aschema *Ana
 		for k, v := range an.references.allRefs {
 			r, erd := replace.DeepestRef(isn.opts.Swagger(), isn.opts.ExpandOpts(false), v)
 			if erd != nil {
-				return fmt.Errorf("at %s, %w", k, erd)
+				return ErrAtKey(k, erd)
 			}
 
 			if isn.opts.flattenContext != nil {

--- a/internal/flatten/replace/errors.go
+++ b/internal/flatten/replace/errors.go
@@ -1,0 +1,61 @@
+package replace
+
+import (
+	"errors"
+	"fmt"
+)
+
+type replaceError string
+
+const (
+	ErrReplace        replaceError = "flatten replace error"
+	ErrUnexpectedType replaceError = "unexpected type used in getPointerFromKey"
+)
+
+func (e replaceError) Error() string {
+	return string(e)
+}
+
+func ErrNoSchemaWithRef(key string, value any) error {
+	return fmt.Errorf("no schema with ref found at %s for %T: %w", key, value, ErrReplace)
+}
+
+func ErrNoSchema(key string) error {
+	return fmt.Errorf("no schema found at %s: %w", key, ErrReplace)
+}
+
+func ErrNotANumber(key string, err error) error {
+	return errors.Join(
+		ErrReplace,
+		fmt.Errorf("%s not a number: %w", key, err),
+	)
+}
+
+func ErrUnhandledParentRewrite(key string, value any) error {
+	return fmt.Errorf("unhandled parent schema rewrite %s: %T: %w", key, value, ErrReplace)
+}
+
+func ErrUnhandledParentType(key string, value any) error {
+	return fmt.Errorf("unhandled type for parent of %s: %T: %w", key, value, ErrReplace)
+}
+
+func ErrNoParent(key string, err error) error {
+	return errors.Join(
+		fmt.Errorf("can't get parent for %s: %w", key, err),
+		ErrReplace,
+	)
+}
+
+func ErrUnhandledContainerType(key string, value any) error {
+	return fmt.Errorf("unhandled container type at %s: %T: %w", key, value, ErrReplace)
+}
+
+func ErrCyclicChain(key string) error {
+	return fmt.Errorf("cannot resolve cyclic chain of pointers under %s: %w", key, ErrReplace)
+}
+
+func ErrInvalidPointerType(key string, value any, err error) error {
+	return fmt.Errorf("invalid type for resolved JSON pointer %s. Expected a schema a, got: %T (%v): %w",
+		key, value, err, ErrReplace,
+	)
+}

--- a/internal/flatten/replace/replace.go
+++ b/internal/flatten/replace/replace.go
@@ -2,6 +2,7 @@ package replace
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -47,7 +48,7 @@ func RewriteSchemaToRef(sp *spec.Swagger, key string, ref spec.Ref) error {
 	case map[string]interface{}: // this happens e.g. if a schema points to an extension unmarshaled as map[string]interface{}
 		return rewriteParentRef(sp, key, ref)
 	default:
-		return fmt.Errorf("no schema with ref found at %s for %T", key, value)
+		return ErrNoSchemaWithRef(key, value)
 	}
 
 	return nil
@@ -72,7 +73,7 @@ func rewriteParentRef(sp *spec.Swagger, key string, ref spec.Ref) error {
 	case *spec.Responses:
 		statusCode, err := strconv.Atoi(entry)
 		if err != nil {
-			return fmt.Errorf("%s not a number: %w", key[1:], err)
+			return ErrNotANumber(key[1:], err)
 		}
 		resp := container.StatusCodeResponses[statusCode]
 		resp.Schema = &spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}
@@ -96,7 +97,7 @@ func rewriteParentRef(sp *spec.Swagger, key string, ref spec.Ref) error {
 	case []spec.Parameter:
 		idx, err := strconv.Atoi(entry)
 		if err != nil {
-			return fmt.Errorf("%s not a number: %w", key[1:], err)
+			return ErrNotANumber(key[1:], err)
 		}
 		param := container[idx]
 		param.Schema = &spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}
@@ -111,7 +112,7 @@ func rewriteParentRef(sp *spec.Swagger, key string, ref spec.Ref) error {
 	case []spec.Schema:
 		idx, err := strconv.Atoi(entry)
 		if err != nil {
-			return fmt.Errorf("%s not a number: %w", key[1:], err)
+			return ErrNotANumber(key[1:], err)
 		}
 		container[idx] = spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}
 
@@ -119,7 +120,7 @@ func rewriteParentRef(sp *spec.Swagger, key string, ref spec.Ref) error {
 		// NOTE: this is necessarily an array - otherwise, the parent would be *Schema
 		idx, err := strconv.Atoi(entry)
 		if err != nil {
-			return fmt.Errorf("%s not a number: %w", key[1:], err)
+			return ErrNotANumber(key[1:], err)
 		}
 		container.Schemas[idx] = spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}
 
@@ -132,7 +133,7 @@ func rewriteParentRef(sp *spec.Swagger, key string, ref spec.Ref) error {
 	// NOTE: can't have case *spec.SchemaOrBool = parent in this case is *Schema
 
 	default:
-		return fmt.Errorf("unhandled parent schema rewrite %s (%T)", key, pvalue)
+		return ErrUnhandledParentRewrite(key, pvalue)
 	}
 
 	return nil
@@ -144,7 +145,7 @@ func getPointerFromKey(sp interface{}, key string) (string, interface{}, error) 
 	case *spec.Schema:
 	case *spec.Swagger:
 	default:
-		panic("unexpected type used in getPointerFromKey")
+		panic(ErrUnexpectedType)
 	}
 	if key == "#/" {
 		return "", sp, nil
@@ -153,14 +154,14 @@ func getPointerFromKey(sp interface{}, key string) (string, interface{}, error) 
 	pth, _ := url.PathUnescape(key[1:])
 	ptr, err := jsonpointer.New(pth)
 	if err != nil {
-		return "", nil, err
+		return "", nil, errors.Join(err, ErrReplace)
 	}
 
 	value, _, err := ptr.Get(sp)
 	if err != nil {
 		debugLog("error when getting key: %s with path: %s", key, pth)
 
-		return "", nil, err
+		return "", nil, errors.Join(err, ErrReplace)
 	}
 
 	return pth, value, nil
@@ -172,7 +173,7 @@ func getParentFromKey(sp interface{}, key string) (string, string, interface{}, 
 	case *spec.Schema:
 	case *spec.Swagger:
 	default:
-		panic("unexpected type used in getPointerFromKey")
+		panic(ErrUnexpectedType)
 	}
 	// unescape chars in key, e.g. "{}" from path params
 	pth, _ := url.PathUnescape(key[1:])
@@ -182,11 +183,11 @@ func getParentFromKey(sp interface{}, key string) (string, string, interface{}, 
 
 	pptr, err := jsonpointer.New(parent)
 	if err != nil {
-		return "", "", nil, err
+		return "", "", nil, errors.Join(err, ErrReplace)
 	}
 	pvalue, _, err := pptr.Get(sp)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("can't get parent for %s: %w", parent, err)
+		return "", "", nil, ErrNoParent(parent, err)
 	}
 
 	return parent, entry, pvalue, nil
@@ -198,7 +199,7 @@ func UpdateRef(sp interface{}, key string, ref spec.Ref) error {
 	case *spec.Schema:
 	case *spec.Swagger:
 	default:
-		panic("unexpected type used in getPointerFromKey")
+		panic(ErrUnexpectedType)
 	}
 	debugLog("updating ref for %s with %s", key, ref.String())
 	pth, value, err := getPointerFromKey(sp, key)
@@ -233,7 +234,7 @@ func UpdateRef(sp interface{}, key string, ref spec.Ref) error {
 		case []spec.Schema:
 			idx, err := strconv.Atoi(entry)
 			if err != nil {
-				return fmt.Errorf("%s not a number: %w", pth, err)
+				return ErrNotANumber(pth, err)
 			}
 			container[idx] = spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}
 
@@ -241,7 +242,7 @@ func UpdateRef(sp interface{}, key string, ref spec.Ref) error {
 			// NOTE: this is necessarily an array - otherwise, the parent would be *Schema
 			idx, err := strconv.Atoi(entry)
 			if err != nil {
-				return fmt.Errorf("%s not a number: %w", pth, err)
+				return ErrNotANumber(pth, err)
 			}
 			container.Schemas[idx] = spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}
 
@@ -251,11 +252,11 @@ func UpdateRef(sp interface{}, key string, ref spec.Ref) error {
 		// NOTE: can't have case *spec.SchemaOrBool = parent in this case is *Schema
 
 		default:
-			return fmt.Errorf("unhandled container type at %s: %T", key, value)
+			return ErrUnhandledContainerType(key, value)
 		}
 
 	default:
-		return fmt.Errorf("no schema with ref found at %s for %T", key, value)
+		return ErrNoSchemaWithRef(key, value)
 	}
 
 	return nil
@@ -277,6 +278,7 @@ func UpdateRefWithSchema(sp *spec.Swagger, key string, sch *spec.Schema) error {
 		if erp != nil {
 			return erp
 		}
+
 		switch container := pvalue.(type) {
 		case spec.Definitions:
 			container[entry] = *sch
@@ -287,7 +289,7 @@ func UpdateRefWithSchema(sp *spec.Swagger, key string, sch *spec.Schema) error {
 		case []spec.Schema:
 			idx, err := strconv.Atoi(entry)
 			if err != nil {
-				return fmt.Errorf("%s not a number: %w", pth, err)
+				return ErrNotANumber(pth, err)
 			}
 			container[idx] = *sch
 
@@ -295,7 +297,7 @@ func UpdateRefWithSchema(sp *spec.Swagger, key string, sch *spec.Schema) error {
 			// NOTE: this is necessarily an array - otherwise, the parent would be *Schema
 			idx, err := strconv.Atoi(entry)
 			if err != nil {
-				return fmt.Errorf("%s not a number: %w", pth, err)
+				return ErrNotANumber(pth, err)
 			}
 			container.Schemas[idx] = *sch
 
@@ -305,7 +307,7 @@ func UpdateRefWithSchema(sp *spec.Swagger, key string, sch *spec.Schema) error {
 		// NOTE: can't have case *spec.SchemaOrBool = parent in this case is *Schema
 
 		default:
-			return fmt.Errorf("unhandled type for parent of [%s]: %T", key, value)
+			return ErrUnhandledParentType(key, value)
 		}
 	case *spec.SchemaOrArray:
 		*refable.Schema = *sch
@@ -313,7 +315,7 @@ func UpdateRefWithSchema(sp *spec.Swagger, key string, sch *spec.Schema) error {
 	case *spec.SchemaOrBool:
 		*refable.Schema = *sch
 	default:
-		return fmt.Errorf("no schema with ref found at %s for %T", key, value)
+		return ErrNoSchemaWithRef(key, value)
 	}
 
 	return nil
@@ -350,8 +352,7 @@ DOWNREF:
 		}
 
 		if _, beenThere := visited[currentRef.String()]; beenThere {
-			return nil,
-				fmt.Errorf("cannot resolve cyclic chain of pointers under %s", currentRef.String())
+			return nil, ErrCyclicChain(currentRef.String())
 		}
 
 		visited[currentRef.String()] = true
@@ -393,10 +394,7 @@ DOWNREF:
 
 			err := asSchema.UnmarshalJSON(asJSON)
 			if err != nil {
-				return nil,
-					fmt.Errorf("invalid type for resolved JSON pointer %s. Expected a schema a, got: %T (%v)",
-						currentRef.String(), value, err,
-					)
+				return nil, ErrInvalidPointerType(currentRef.String(), value, err)
 			}
 			warnings = append(warnings, fmt.Sprintf("found $ref %q (response) interpreted as schema", currentRef.String()))
 
@@ -411,10 +409,7 @@ DOWNREF:
 			asJSON, _ := refable.MarshalJSON()
 			var asSchema spec.Schema
 			if err := asSchema.UnmarshalJSON(asJSON); err != nil {
-				return nil,
-					fmt.Errorf("invalid type for resolved JSON pointer %s. Expected a schema a, got: %T (%v)",
-						currentRef.String(), value, err,
-					)
+				return nil, ErrInvalidPointerType(currentRef.String(), value, err)
 			}
 
 			warnings = append(warnings, fmt.Sprintf("found $ref %q (parameter) interpreted as schema", currentRef.String()))
@@ -433,10 +428,7 @@ DOWNREF:
 			asJSON, _ := json.Marshal(refable)
 			var asSchema spec.Schema
 			if err := asSchema.UnmarshalJSON(asJSON); err != nil {
-				return nil,
-					fmt.Errorf("unhandled type to resolve JSON pointer %s. Expected a Schema, got: %T (%v)",
-						currentRef.String(), value, err,
-					)
+				return nil, ErrInvalidPointerType(currentRef.String(), value, err)
 			}
 			warnings = append(warnings, fmt.Sprintf("found $ref %q (%T) interpreted as schema", currentRef.String(), refable))
 
@@ -454,7 +446,7 @@ DOWNREF:
 	}
 
 	if sch == nil {
-		return nil, fmt.Errorf("no schema found at %s", currentRef.String())
+		return nil, ErrNoSchema(currentRef.String())
 	}
 
 	return &DeepestRefResult{Ref: currentRef, Schema: sch, Warnings: warnings}, nil

--- a/internal/flatten/sortref/keys.go
+++ b/internal/flatten/sortref/keys.go
@@ -179,7 +179,8 @@ func (s SplitKey) ResponseName() string {
 
 // PathItemRef constructs a $ref object from a split key of the form /{path}/{method}
 func (s SplitKey) PathItemRef() spec.Ref {
-	if len(s) < 3 {
+	const minValidPathItems = 3
+	if len(s) < minValidPathItems {
 		return spec.Ref{}
 	}
 

--- a/mixin.go
+++ b/mixin.go
@@ -391,7 +391,7 @@ func mergeInfo(primary *spec.Info, m *spec.Info) []string {
 	}
 
 	if primary.Title == "" {
-		primary.Description = m.Description
+		primary.Title = m.Title
 	}
 
 	if primary.TermsOfService == "" {

--- a/schema.go
+++ b/schema.go
@@ -1,8 +1,6 @@
 package analysis
 
 import (
-	"errors"
-
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
 )
@@ -19,7 +17,7 @@ type SchemaOpts struct {
 // patterns.
 func Schema(opts SchemaOpts) (*AnalyzedSchema, error) {
 	if opts.Schema == nil {
-		return nil, errors.New("no schema to analyze")
+		return nil, ErrNoSchema
 	}
 
 	a := &AnalyzedSchema{


### PR DESCRIPTION
* addressed linting issues, especially those related to non-wrapping errors: refactored all calls to fmt.Errorf()
* fixes #114: unfortunate copy paste typo in mixin.go