### PR TITLE
test: removed special case for handling testing dirs on windows

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -11,11 +11,9 @@ import (
 	"runtime"
 )
 
-var (
-	output = os.Stdout
-)
+var output = os.Stdout //nolint:gochecknoglobals // this is on purpose to be overridable during tests
 
-// GetLogger provides a prefix debug logger
+// GetLogger provides a prefix debug logger.
 func GetLogger(prefix string, debug bool) func(string, ...any) {
 	if debug {
 		logger := log.New(output, prefix+":", log.LstdFlags)


### PR DESCRIPTION
https://github.com/golang/go/issues/71544 is still officially open. However a fix has been committed to go codebase.

This issue is not really blocking: the problem lies on windows not reliaby cleaning up the temporary directory.