### PR TITLE
fix(flatten): in options, guarded against possible json serialization of

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,11 @@ linters:
   disable:
     - depguard
     - funlen
+    - goconst
     - godox
     - gomoddirectives
+    - gomodguard
+    - gomodguard_v2
     - exhaustruct
     - nlreturn
     - nonamedreturns

--- a/flatten.go
+++ b/flatten.go
@@ -575,7 +575,7 @@ func stripOAIGenForRef(opts *FlattenOpts, k string, r *newRef) (bool, error) {
 	}
 
 	// rewrite other parents to point to first parent
-	if len(pr) > 1 {
+	if len(pr) > 1 { //nolint:nestif // should be refactored at a later time
 		for _, p := range pr[1:] {
 			replacingRef := spec.MustCreateRef(pr[0])
 

--- a/flatten_options.go
+++ b/flatten_options.go
@@ -33,7 +33,7 @@ type FlattenOpts struct {
 	RemoveUnused    bool              // When true, remove unused parameters, responses and definitions after expansion/flattening
 	ContinueOnError bool              // Continue when spec expansion issues are found
 	KeepNames       bool              // Do not attempt to jsonify names from references when flattening
-	ManglerOpts     []mangling.Option // Options for the name mangler used to jsonify names
+	ManglerOpts     []mangling.Option `json:"-"` // Options for the name mangler used to jsonify names
 
 	// PathLoaderWithOptions injects the document loader used to resolve remote and relative $ref
 	// while flattening or expanding the specification. It matches the option-aware loader signature
@@ -43,7 +43,7 @@ type FlattenOpts struct {
 	// confined loader — for example one built with loading.WithRoot (to confine local reads) and
 	// loading.WithHTTPClient (to restrict remote fetches), or a restricted loader from
 	// go-openapi/loads. Left nil, the spec package default (unsandboxed) loader is used.
-	PathLoaderWithOptions func(string, ...loading.Option) (json.RawMessage, error)
+	PathLoaderWithOptions func(string, ...loading.Option) (json.RawMessage, error) `json:"-"`
 
 	/* Extra keys */
 	_ struct{} // require keys

--- a/internal/antest/helpers_test.go
+++ b/internal/antest/helpers_test.go
@@ -101,7 +101,7 @@ info:
 	}
 
 	require.NoError(t,
-		os.WriteFile(file, data, 0o600), //nolint:gosec // false positive on temp test dir: G703: Path traversal via taint analysis.
+		os.WriteFile(file, data, 0o600),
 	)
 
 	return file, func() {}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
 // SPDX-License-Identifier: Apache-2.0
 
-package debug //nolint:revive // this package is called debug and there is no confusion with the standard library for that.
+package debug
 
 import (
 	"os"
@@ -32,7 +32,7 @@ func TestDebug(t *testing.T) {
 	tmpFile.Close()
 	tmpFileClosed = true
 
-	flushed, err := os.ReadFile(tmpName) //nolint:gosec // false positive on temp test dir: G703: Path traversal via taint analysis.
+	flushed, err := os.ReadFile(tmpName)
 	require.NoError(t, err)
 
 	assert.StringContainsT(t, string(flushed), "A debug: a string")
@@ -53,7 +53,7 @@ func TestDebug(t *testing.T) {
 	tmpEmptyFile.Close()
 	tmpEmptyFileClosed = true
 
-	flushed, err = os.ReadFile(tmpEmpty) //nolint:gosec // false positive on temp test dir: G703: Path traversal via taint analysis.
+	flushed, err = os.ReadFile(tmpEmpty)
 	require.NoError(t, err)
 
 	assert.Empty(t, flushed)


### PR DESCRIPTION
funcs

Non-serializable exported fields should be guarded by json tag "-".

Also: updated linter (discarded goconst, deprecated linters, deprecated nolint directives). Acknowledged one remaining high complexity in flatter.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
