### PR TITLE
tests: gate remote flatten fixtures as long tests

### DIFF
--- a/flatten_test.go
+++ b/flatten_test.go
@@ -1202,6 +1202,10 @@ func TestFlatten_1851(t *testing.T) {
 }
 
 func TestFlatten_RemoteAbsolute(t *testing.T) {
+	if !antest.LongTestsEnabled() {
+		t.Skip("requires remote fixtures; use -enable-long to run")
+	}
+
 	for _, toPin := range []string{
 		// this one has simple remote ref pattern
 		filepath.Join("fixtures", "bugs", "remote-absolute", "swagger-mini.json"),


### PR DESCRIPTION
`TestFlatten_RemoteAbsolute` fetches the CloudEvents v0.2 schema from `raw.githubusercontent.com`. Reuse the existing `-enable-long` test switch so the default unit suite works offline while preserving an explicit path to run the remote fixture coverage.

Tested with `go test ./...`.