### PR TITLE
feat: expose where each $ref is declared

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -585,6 +585,20 @@ func (s *Spec) AllRefs() (result []spec.Ref) {
 	return
 }
 
+// AllRefsByLocation returns all the references found in the document, keyed by
+// where each one is declared.
+//
+// Keys are local JSON references into the analyzed document, with tokens
+// escaped as per RFC 6901, e.g. "#/paths/~1pets/get/responses/200/schema".
+//
+// Unlike [Spec.AllRefs], the result is not deduplicated: the same reference
+// declared in several places appears under each of its locations.
+//
+// The map is cloned to avoid accidental changes.
+func (s *Spec) AllRefsByLocation() map[string]spec.Ref {
+	return cloneRefMap(s.references.allRefs)
+}
+
 // ParameterPatterns returns all the patterns found in parameters
 // the map is cloned to avoid accidental changes.
 func (s *Spec) ParameterPatterns() map[string]string {
@@ -1048,6 +1062,13 @@ func (s *Spec) analyzeSchema(name string, schema *spec.Schema, prefix string) {
 
 func cloneStringMap(source map[string]string) map[string]string {
 	res := make(map[string]string, len(source))
+	maps.Copy(res, source)
+
+	return res
+}
+
+func cloneRefMap(source map[string]spec.Ref) map[string]spec.Ref {
+	res := make(map[string]spec.Ref, len(source))
 	maps.Copy(res, source)
 
 	return res

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -289,6 +289,82 @@ func TestAnalyzer_ReferenceAnalysis(t *testing.T) {
 	assert.Lenf(t, an.AllItemsReferences(), 3, "Expected 3 items references in this spec")
 }
 
+func TestAnalyzer_AllRefsByLocation(t *testing.T) {
+	t.Parallel()
+
+	doc := antest.LoadOrFail(t, filepath.Join("fixtures", "references.yml"))
+	an := New(doc)
+
+	byLocation := an.AllRefsByLocation()
+	require.NotEmpty(t, byLocation)
+
+	t.Run("should key references by where they are declared", func(t *testing.T) {
+		t.Parallel()
+
+		for _, fixture := range []struct {
+			Location string
+			Expected string
+		}{
+			{
+				Location: "#/paths/~1some~1where~1{id}/parameters/0",
+				Expected: "#/parameters/idParam",
+			},
+			{
+				Location: "#/paths/~1some~1where~1{id}/get/parameters/0",
+				Expected: "#/parameters/limitParam",
+			},
+			{
+				Location: "#/paths/~1some~1where~1{id}/get/parameters/1/items",
+				Expected: "#/definitions/named",
+			},
+			{
+				Location: "#/responses/notFound/schema",
+				Expected: "#/definitions/error",
+			},
+			{
+				Location: "#/paths/~1other~1place",
+				Expected: "#/x-shared-path/getItems",
+			},
+		} {
+			require.MapContainsT(t, byLocation, fixture.Location)
+			ref := byLocation[fixture.Location]
+			assert.EqualT(t, fixture.Expected, ref.String(),
+				"unexpected reference at %q", fixture.Location)
+		}
+	})
+
+	t.Run("should agree with AllRefs on the referenced values", func(t *testing.T) {
+		t.Parallel()
+
+		// AllRefs is the same set, deduplicated and stripped of empty references
+		unique := make(map[string]struct{}, len(byLocation))
+		for _, declared := range byLocation {
+			ref := declared
+			if ref.String() == "" {
+				continue
+			}
+			unique[ref.String()] = struct{}{}
+		}
+
+		assert.Len(t, an.AllRefs(), len(unique))
+		for _, found := range an.AllRefs() {
+			ref := found
+			assert.MapContainsT(t, unique, ref.String())
+		}
+	})
+
+	t.Run("should return a clone", func(t *testing.T) {
+		t.Parallel()
+
+		const location = "#/responses/notFound/schema"
+		byLocation := an.AllRefsByLocation()
+		delete(byLocation, location)
+
+		require.MapContainsT(t, an.AllRefsByLocation(), location,
+			"expected the analyzer to be unaffected by changes to the returned map")
+	})
+}
+
 type expectedPattern struct {
 	Key     string
 	Pattern string


### PR DESCRIPTION
AllRefsByLocation returns the analyzed references keyed by the location they were found at, as local JSON references into the document:

    "#/paths/~1pets/get/responses/200/schema": "#/definitions/Pet"

The analyzer already indexed references that way, but AllRefs and AllReferences both range over the map taking only its values, so callers wanting to report where a reference sits had no way to reach the keys. Unlike AllRefs, the result is not deduplicated: a reference declared in several places appears under each of its locations.

Additive: nothing existing changes behaviour.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
